### PR TITLE
Introduce `hoardable_options` per model

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,25 +222,40 @@ end
 
 ### Configuration
 
-There are two configurable options currently:
+There are three configurable options currently:
 
 ```ruby
 Hoardable.enabled # => default true
+Hoardable.version_updates # => default true
 Hoardable.save_trash # => default true
 ```
 
-`Hoardable.enabled` controls whether versions will be created at all.
+`Hoardable.enabled` controls whether versions will be ever be created.
+
+`Hoardable.version_updates` controls whether versions get created on record updates.
 
 `Hoardable.save_trash` controls whether to create versions upon record deletion. When this is set to
 `false`, all versions of a record will be deleted when the record is destroyed.
 
-If you would like to temporarily set a config setting, you can use `Hoardable.with` as well:
+If you would like to temporarily set a config setting, you can use `Hoardable.with`:
 
 ```ruby
 Hoardable.with(enabled: false) do
   post.update!(title: 'unimportant change to create version for')
 end
 ```
+
+You can also configure these variables per `ActiveRecord` class as well using `hoardable_options`:
+
+```ruby
+class Comment < ActiveRecord::Base
+  include Hoardable::Model
+  hoardable_options version_updates: false
+end
+```
+
+If either the model-level option or global option for a configuration variable is set to `false`,
+that behavior will be disabled.
 
 ### Relationships
 

--- a/lib/hoardable/hoardable.rb
+++ b/lib/hoardable/hoardable.rb
@@ -7,16 +7,13 @@ module Hoardable
   DATA_KEYS = %i[meta whodunit note event_uuid].freeze
   # Symbols for use with setting {Hoardable} configuration. See {file:README.md#configuration
   # README} for more.
-  CONFIG_KEYS = %i[enabled save_trash].freeze
+  CONFIG_KEYS = %i[enabled version_updates save_trash].freeze
 
   # @!visibility private
   VERSION_CLASS_SUFFIX = 'Version'
 
   # @!visibility private
   VERSION_TABLE_SUFFIX = "_#{VERSION_CLASS_SUFFIX.tableize}"
-
-  # @!visibility private
-  SAVE_TRASH_ENABLED = -> { Hoardable.save_trash }.freeze
 
   # @!visibility private
   DURING_QUERY = '_during @> ?::timestamp'

--- a/lib/hoardable/model.rb
+++ b/lib/hoardable/model.rb
@@ -8,6 +8,29 @@ module Hoardable
   module Model
     extend ActiveSupport::Concern
 
+    class_methods do
+      # @!visibility private
+      attr_reader :_hoardable_options
+
+      # If called with a hash, this will set the model-level +Hoardable+ configuration variables. If
+      # called without an argument it will return the computed +Hoardable+ configuration considering
+      # both model-level and global values.
+      #
+      # @param hash [Hash] The +Hoardable+ configuration for the model. Keys must be present in
+      #   {CONFIG_KEYS}
+      # @return [Hash]
+      def hoardable_options(hash = nil)
+        if hash
+          @_hoardable_options = hash.slice(*Hoardable::CONFIG_KEYS)
+        else
+          @_hoardable_options ||= {}
+          Hoardable::CONFIG_KEYS.to_h do |key|
+            [key, Hoardable.send(key) != false && @_hoardable_options[key] != false]
+          end
+        end
+      end
+    end
+
     included do
       define_model_callbacks :versioned
       define_model_callbacks :reverted, only: :after

--- a/lib/hoardable/version.rb
+++ b/lib/hoardable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hoardable
-  VERSION = '0.1.3'
+  VERSION = '0.1.4'
 end

--- a/sig/hoardable.rbs
+++ b/sig/hoardable.rbs
@@ -1,10 +1,9 @@
 module Hoardable
   VERSION: String
   DATA_KEYS: [:meta, :whodunit, :note, :event_uuid]
-  CONFIG_KEYS: [:enabled, :save_trash]
+  CONFIG_KEYS: [:enabled, :version_updates, :save_trash]
   VERSION_CLASS_SUFFIX: String
   VERSION_TABLE_SUFFIX: String
-  SAVE_TRASH_ENABLED: ^-> untyped
   DURING_QUERY: String
   self.@context: Hash[untyped, untyped]
   self.@config: untyped
@@ -33,6 +32,8 @@ module Hoardable
 
     private
     def hoardable_callbacks_enabled: -> untyped
+    def hoardable_save_trash: -> untyped
+    def hoardable_version_updates: -> untyped
     def insert_hoardable_version_on_update: -> untyped
     def insert_hoardable_version_on_destroy: -> untyped
     def insert_hoardable_version: (String operation, untyped attrs) -> untyped
@@ -69,6 +70,9 @@ module Hoardable
   module Model
     include VersionModel
     include SourceModel
+
+    attr_reader _hoardable_options: Hash[untyped, untyped]
+    def hoardable_options: (?nil hash) -> untyped
   end
 
   class MigrationGenerator

--- a/test/support/database.rb
+++ b/test/support/database.rb
@@ -61,6 +61,7 @@ def generate_versions_table(table_name)
   "Create#{table_name.classify.singularize}Versions".constantize.migrate(:up)
 end
 
-generate_versions_table('post')
-generate_versions_table('comment')
-generate_versions_table('book')
+generate_versions_table('Post')
+generate_versions_table('Comment')
+generate_versions_table('Book')
+generate_versions_table('Library')

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -2,6 +2,7 @@
 
 class Post < ActiveRecord::Base
   include Hoardable::Model
+  hoardable_options version_updates: true, save_trash: true
   belongs_to :user
   has_many :comments, dependent: :destroy
   attr_reader :_hoardable_operation, :reverted, :untrashed, :hoardable_version_id
@@ -48,5 +49,7 @@ class Book < ActiveRecord::Base
 end
 
 class Library < ActiveRecord::Base
+  include Hoardable::Model
   has_many :books, dependent: :destroy
+  hoardable_options save_trash: false
 end

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -191,6 +191,13 @@ class TestModel < Minitest::Test
     end
   end
 
+  it 'does not create version when version_updates is false' do
+    Hoardable.with(version_updates: false) do
+      update_post
+      assert_equal post.versions.size, 0
+    end
+  end
+
   it 'can opt-out of versioning on deletion' do
     Hoardable.with(save_trash: false) do
       update_post
@@ -198,6 +205,13 @@ class TestModel < Minitest::Test
       post.destroy!
       assert_equal PostVersion.count, 0
     end
+  end
+
+  it 'can disallow version_updates with Model configuration' do
+    Post.hoardable_options(version_updates: false)
+    update_post
+    assert_equal post.versions.size, 0
+    Post.hoardable_options(version_updates: true)
   end
 
   def expect_whodunit
@@ -311,5 +325,14 @@ class TestModel < Minitest::Test
     untrashed_book = BookVersion.find(book_id).untrash!
     assert_equal untrashed_book.title, new_title
     assert_equal untrashed_book.id, book_id
+  end
+
+  it 'does not save_trash when model is configured not to' do
+    library = Library.create!(name: 'Lib')
+    library.update!(name: 'Library')
+    assert_equal library.versions.size, 1
+    library.destroy!
+    assert_equal Library.count, 0
+    assert_equal LibraryVersion.count, 0
   end
 end


### PR DESCRIPTION
* Allows for overriding configuration options on a per model level
* Introduces a configuration option for `version_updates`, so that one could opt into creating versions only on deletion, for example