### PR TITLE
Insert version upon `untrash!` and add `.at` to `SourceModel`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## [Unreleased]
 
+## [0.5.0] - 2022-09-25
+
+- **Breaking Change** - Untrashing a version will now insert a version for the untrash event with
+  it's own temporal timespan. This simplifies the ability to query versions temporarily for when
+  they were trashed or not. This changes, but corrects, temporal query results using `.at`.
+
+- **Breaking Change** - Because of the above, a new operation enum value of "insert" was added. If
+  you already have the `hoardable_operation` enum in your PostgreSQL schema, you can add it by
+  executing the following SQL in a new migration: `ALTER TYPE hoardable_operation ADD VALUE
+  'insert';`.
+
 ## [0.4.0] - 2022-09-24
 
 - **Breaking Change** - Trashed versions now pull from the same postgres sequenced used by the

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Post.find(post.id) # raises ActiveRecord::RecordNotFound
 trashed_post = post.versions.trashed.last
 trashed_post.id # => 2
 trashed_post.untrash!
-Post.find(post.id) # #<Post:0x000000010d44fa30>
+Post.find(post.id) # #<Post>
 ```
 
 ### Querying and Temporal Lookup
@@ -132,14 +132,23 @@ post.versions.where(user_id: Current.user.id, body: "Cool!")
 If you want to look-up the version of a record at a specific time, you can use the `.at` method:
 
 ```ruby
-post.at(1.day.ago) # => #<PostVersion:0x000000010d44fa30>
-# or
-PostVersion.at(1.day.ago).find_by(post_id: post.id) # => #<PostVersion:0x000000010d44fa30>
+post.at(1.day.ago) # => #<PostVersion>
+# or you can use the scope on the version model class
+PostVersion.at(1.day.ago).find_by(post_id: post.id) # => #<PostVersion>
 ```
 
-_Note:_ A `Version` is not created upon initial parent model creation. If you would like to
-accurately capture the valid temporal frame of the first version, make sure your model’s table has a
-`created_at` timestamp field.
+The source model class also has an `.at` method:
+
+``` ruby
+Post.at(1.day.ago) # => [#<Post>, #<Post>]
+```
+
+This will return an ActiveRecord scoped query of all `Posts` and `PostVersions` that were valid at
+that time, all cast as instances of `Post`.
+
+_Note:_ A `Version` is not created upon initial parent model creation. To accurately track the
+beginning of the first temporal period, you will need to ensure the source model table has a
+`created_at` timestamp column.
 
 By default, `hoardable` will keep copies of records you have destroyed. You can query them
 specifically with:

--- a/lib/generators/hoardable/templates/migration.rb.erb
+++ b/lib/generators/hoardable/templates/migration.rb.erb
@@ -2,7 +2,7 @@
 
 class Create<%= class_name.singularize %>Versions < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
   def change
-    create_enum :hoardable_operation, %w[update delete]
+    create_enum :hoardable_operation, %w[update delete insert]
     create_table :<%= singularized_table_name %>_versions, id: false, options: 'INHERITS (<%= table_name %>)' do |t|
       t.jsonb :_data
       t.tsrange :_during, null: false

--- a/lib/generators/hoardable/templates/migration_6.rb.erb
+++ b/lib/generators/hoardable/templates/migration_6.rb.erb
@@ -11,7 +11,7 @@ class Create<%= class_name.singularize %>Versions < ActiveRecord::Migration[<%= 
                 SELECT 1 FROM pg_type t
                 WHERE t.typname = 'hoardable_operation'
               ) THEN
-                CREATE TYPE hoardable_operation AS ENUM ('update', 'delete');
+                CREATE TYPE hoardable_operation AS ENUM ('update', 'delete', 'insert');
               END IF;
           END
           $$;

--- a/lib/hoardable/associations.rb
+++ b/lib/hoardable/associations.rb
@@ -18,7 +18,7 @@ module Hoardable
         define_method(trashable_relationship_name) do
           source_reflection = self.class.reflections[name.to_s]
           version_class = source_reflection.klass.version_class
-          version_class.trashed.order(_during: :desc).find_by(
+          version_class.trashed.only_most_recent.find_by(
             version_class.hoardable_source_foreign_key => source_reflection.foreign_key
           )
         end

--- a/lib/hoardable/source_model.rb
+++ b/lib/hoardable/source_model.rb
@@ -34,18 +34,32 @@ module Hoardable
 
       # Returns all +versions+ in ascending order of their temporal timeframes.
       has_many(
-        :versions, -> { order(:_during) },
+        :versions, -> { order('UPPER(_during) ASC') },
         dependent: nil,
         class_name: version_class.to_s,
         inverse_of: model_name.i18n_key
       )
+
+      # @!scope class
+      # @!method at
+      # @return [ActiveRecord<Object>]
+      #
+      # Returns instances of the source model and versions that were valid at the supplied
+      # +datetime+ or +time+, all cast as instances of the source model.
+      scope :at, lambda { |datetime|
+        versioned = version_class.at(datetime)
+        include_versions.where(id: versioned.select('id')).or(
+          where.not(id: versioned.select(version_class.hoardable_source_foreign_key))
+            .where.not(id: version_class.select(version_class.hoardable_source_foreign_key).trashed_at(datetime))
+        )
+      }
     end
 
     # Returns a boolean of whether the record is actually a trashed +version+.
     #
     # @return [Boolean]
     def trashed?
-      versions.trashed.limit(1).order(_during: :desc).first&.hoardable_source_foreign_id == id
+      versions.trashed.only_most_recent.first&.hoardable_source_foreign_id == id
     end
 
     # Returns the +version+ at the supplied +datetime+ or +time+. It will return +self+ if there is
@@ -91,7 +105,7 @@ module Hoardable
     end
 
     def insert_hoardable_version(operation)
-      @hoardable_version = initialize_hoardable_version(operation, attributes_before_type_cast.without('id'))
+      @hoardable_version = initialize_hoardable_version(operation)
       run_callbacks(:versioned) do
         yield
         hoardable_version.save(validate: false, touch: false)
@@ -102,9 +116,9 @@ module Hoardable
       Thread.current[:hoardable_event_uuid] ||= ActiveRecord::Base.connection.query('SELECT gen_random_uuid();')[0][0]
     end
 
-    def initialize_hoardable_version(operation, attrs)
+    def initialize_hoardable_version(operation)
       versions.new(
-        attrs.merge(
+        attributes_before_type_cast.without('id').merge(
           changes.transform_values { |h| h[0] },
           {
             _event_uuid: find_or_initialize_hoardable_event_uuid,

--- a/lib/hoardable/version.rb
+++ b/lib/hoardable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hoardable
-  VERSION = '0.4.0'
+  VERSION = '0.5.0'
 end

--- a/lib/hoardable/version_model.rb
+++ b/lib/hoardable/version_model.rb
@@ -93,7 +93,7 @@ module Hoardable
         superscope = self.class.superclass.unscoped
         superscope.insert(hoardable_source_attributes.merge('id' => hoardable_source_foreign_id))
         superscope.find(hoardable_source_foreign_id).tap do |untrashed|
-          untrashed.send('initialize_hoardable_version', 'insert').save(validate: false, touch: false)
+          untrashed.send('insert_hoardable_version_on_untrashed')
           untrashed.instance_variable_set(:@hoardable_version, self)
           untrashed.run_callbacks(:untrashed)
         end


### PR DESCRIPTION
Untrashing a version will now insert a version for the untrash event with it's own temporal timespan. This simplifies the ability to query versions temporarily for when they were trashed or not. This changes, but corrects, temporal query results using `.at`.

Because of the above, a new operation enum value of "insert" was added. If you already have the `hoardable_operation` enum in your PostgreSQL schema, you can add it by executing the following SQL in a new migration: `ALTER TYPE hoardable_operation ADD VALUE 'insert';`.

Additionally an `.at` scope was added to the source model class as well, to flexibly query a model for the state of records of that type at a given datetime or time.