### PR TITLE
use `hoardable_source_id` as the foreign key on `versions` tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,20 @@
 ## [Unreleased]
 
+- Stability is coming.
+
+## [0.7.0] - 2022-09-29
+
+- **Breaking Change** - Continuing along with the change below, the `foreign_key` for this
+  relationship has now changed to `hoardable_source_id` for all `_versions` tables. The intent is to
+  never leave room for confliction of foreign keys for existing relationships. This can be resolved
+  by renaming the columns from their i18n model name derived column names to `hoardable_source_id`.
+
 ## [0.6.0] - 2022-09-28
 
 - **Breaking Change** - Previously, a source model would `has_many :versions` with an inverse
-  relationship of the i18n interpreted name of the source model. Now it simply `has_many :versions,
-  inverse_of :hoardable_source` to not potentially conflict with previously existing relationships.
+  relationship based on the i18n interpreted name of the source model. Now it simply `has_many
+  :versions, inverse_of :hoardable_source` to not potentially conflict with previously existing
+  relationships.
 
 ## [0.5.0] - 2022-09-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 ## [0.7.0] - 2022-09-29
 
-- **Breaking Change** - Continuing along with the change below, the `foreign_key` for this
-  relationship has now changed to `hoardable_source_id` for all `_versions` tables. The intent is to
-  never leave room for confliction of foreign keys for existing relationships. This can be resolved
-  by renaming the columns from their i18n model name derived column names to `hoardable_source_id`.
+- **Breaking Change** - Continuing along with the change below, the `foreign_key` on the `_versions`
+  tables is now changed to `hoardable_source_id` instead of the i18n model name dervied foreign key.
+  The intent is to never leave room for conflict of foreign keys for existing relationships. This
+  can be resolved by renaming the foreign key columns from their i18n model name derived column
+  names to `hoardable_source_id`, i.e. `rename_column :post_versions, :post_id, :hoardable_source_id`.
 
 ## [0.6.0] - 2022-09-28
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ irb
 >> Post
 => Post(id: integer, body: text, user_id: integer, created_at: datetime)
 >> PostVersion
-=> PostVersion(id: integer, body: text, user_id: integer, created_at: datetime, _data: jsonb, _during: tsrange, post_id: integer)
+=> PostVersion(id: integer, body: text, user_id: integer, created_at: datetime, _data: jsonb, _during: tsrange, hoardable_source_id: integer)
 ```
 
 A `Post` now `has_many :versions`. With the default configuration, whenever an update and deletion
@@ -134,7 +134,7 @@ If you want to look-up the version of a record at a specific time, you can use t
 ```ruby
 post.at(1.day.ago) # => #<PostVersion>
 # or you can use the scope on the version model class
-PostVersion.at(1.day.ago).find_by(post_id: post.id) # => #<PostVersion>
+PostVersion.at(1.day.ago).find_by(hoardable_source_id: post.id) # => #<PostVersion>
 ```
 
 The source model class also has an `.at` method:

--- a/lib/generators/hoardable/templates/migration.rb.erb
+++ b/lib/generators/hoardable/templates/migration.rb.erb
@@ -8,11 +8,11 @@ class Create<%= class_name.singularize %>Versions < ActiveRecord::Migration[<%= 
       t.tsrange :_during, null: false
       t.uuid :_event_uuid, null: false, index: true
       t.enum :_operation, enum_type: 'hoardable_operation', null: false, index: true
-      t.<%= foreign_key_type %> :<%= singularized_table_name %>_id, null: false, index: true
+      t.<%= foreign_key_type %> :hoardable_source_id, null: false, index: true
     end
     add_index(
       :<%= singularized_table_name %>_versions,
-      %i[_during <%= singularized_table_name %>_id],
+      %i[_during hoardable_source_id],
       name: 'idx_<%= singularized_table_name %>_versions_temporally'
     )
   end

--- a/lib/generators/hoardable/templates/migration_6.rb.erb
+++ b/lib/generators/hoardable/templates/migration_6.rb.erb
@@ -23,11 +23,11 @@ class Create<%= class_name.singularize %>Versions < ActiveRecord::Migration[<%= 
       t.tsrange :_during, null: false
       t.uuid :_event_uuid, null: false, index: true
       t.column :_operation, :hoardable_operation, null: false, index: true
-      t.<%= foreign_key_type %> :<%= singularized_table_name %>_id, null: false, index: true
+      t.<%= foreign_key_type %> :hoardable_source_id, null: false, index: true
     end
     add_index(
       :<%= singularized_table_name %>_versions,
-      %i[_during <%= singularized_table_name %>_id],
+      %i[_during hoardable_source_id],
       name: 'idx_<%= singularized_table_name %>_versions_temporally'
     )
   end

--- a/lib/hoardable/associations.rb
+++ b/lib/hoardable/associations.rb
@@ -19,7 +19,7 @@ module Hoardable
           source_reflection = self.class.reflections[name.to_s]
           version_class = source_reflection.klass.version_class
           version_class.trashed.only_most_recent.find_by(
-            version_class.hoardable_source_foreign_key => source_reflection.foreign_key
+            hoardable_source_id: source_reflection.foreign_key
           )
         end
 

--- a/lib/hoardable/source_model.rb
+++ b/lib/hoardable/source_model.rb
@@ -45,7 +45,8 @@ module Hoardable
         :versions, -> { order('UPPER(_during) ASC') },
         dependent: nil,
         class_name: version_class.to_s,
-        inverse_of: :hoardable_source
+        inverse_of: :hoardable_source,
+        foreign_key: :hoardable_source_id
       )
 
       # @!scope class
@@ -56,7 +57,7 @@ module Hoardable
       # +datetime+ or +time+, all cast as instances of the source model.
       scope :at, lambda { |datetime|
         include_versions.where(id: version_class.at(datetime).select('id')).or(
-          where.not(id: version_class.select(version_class.hoardable_source_foreign_key).where(DURING_QUERY, datetime))
+          where.not(id: version_class.select(:hoardable_source_id).where(DURING_QUERY, datetime))
         )
       }
     end

--- a/lib/hoardable/version.rb
+++ b/lib/hoardable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hoardable
-  VERSION = '0.6.0'
+  VERSION = '0.7.0'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,5 +17,5 @@ end
 
 FileUtils.rm_f Dir.glob("#{tmp_dir}/**/*")
 
-require 'support/models'
-require 'support/database'
+require_relative 'support/models'
+require_relative 'support/database'

--- a/test/test_migration_generator.rb
+++ b/test/test_migration_generator.rb
@@ -11,14 +11,14 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
   def shared_post_assertions
     assert_migration 'db/migrate/create_post_versions.rb' do |migration|
       assert_match(/create_table :post_versions/, migration)
-      assert_match(/t.bigint :post_id/, migration)
+      assert_match(/t.bigint :hoardable_source_id/, migration)
     end
   end
 
   def shared_book_assertions(foreign_key_type = 'uuid')
     assert_migration 'db/migrate/create_book_versions.rb' do |migration|
       assert_match(/create_table :book_versions/, migration)
-      assert_match("t.#{foreign_key_type} :book_id", migration)
+      assert_match("t.#{foreign_key_type} :hoardable_source_id", migration)
     end
   end
 

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -69,14 +69,14 @@ class TestModel < Minitest::Test
     post.destroy!
     datetime4 = DateTime.now
     assert_equal post.at(datetime1).title, 'Headline'
-    assert_equal PostVersion.at(datetime1).find_by(post_id: post.id).title, 'Headline'
+    assert_equal PostVersion.at(datetime1).find_by(hoardable_source_id: post.id).title, 'Headline'
     assert_equal post.at(datetime2).title, 'New Headline'
-    assert_equal PostVersion.at(datetime2).find_by(post_id: post.id).title, 'New Headline'
+    assert_equal PostVersion.at(datetime2).find_by(hoardable_source_id: post.id).title, 'New Headline'
     assert_equal post.at(datetime3).title, 'Revert'
-    assert_equal PostVersion.at(datetime3).find_by(post_id: post.id).title, 'Revert'
+    assert_equal PostVersion.at(datetime3).find_by(hoardable_source_id: post.id).title, 'Revert'
     assert_equal post.trashed?, true
     assert_equal post.at(datetime4).title, 'Revert'
-    assert_nil PostVersion.at(datetime4).find_by(post_id: post.id)
+    assert_nil PostVersion.at(datetime4).find_by(hoardable_source_id: post.id)
   end
 
   it 'can revert to version at a datetime' do
@@ -127,7 +127,7 @@ class TestModel < Minitest::Test
     assert post.trashed?
     assert_raises(ActiveRecord::RecordNotFound) { Post.find(post.id) }
     version = PostVersion.last
-    assert_equal version.post_id, post_id
+    assert_equal version.hoardable_source_id, post_id
     untrashed_post = version.untrash!
     assert_equal untrashed_post.attributes.without('updated_at'), attributes
     refute post.reload.trashed?
@@ -290,7 +290,7 @@ class TestModel < Minitest::Test
     post.comments.create!(body: 'Comment 1')
     post.comments.create!(body: 'Comment 2')
     post.destroy!
-    PostVersion.trashed.find_by(post_id: post.id)
+    PostVersion.trashed.find_by(hoardable_source_id: post.id)
   end
 
   it 'recursively creates trashed versions with shared event_uuid' do
@@ -316,8 +316,8 @@ class TestModel < Minitest::Test
   end
 
   it 'creates a version class with a foreign key type that matches the primary key' do
-    assert_equal Post.version_class.columns.find { |col| col.name == 'post_id' }.sql_type, 'bigint'
-    assert_equal Book.version_class.columns.find { |col| col.name == 'book_id' }.sql_type, 'uuid'
+    assert_equal Post.version_class.columns.find { |col| col.name == 'hoardable_source_id' }.sql_type, 'bigint'
+    assert_equal Book.version_class.columns.find { |col| col.name == 'hoardable_source_id' }.sql_type, 'uuid'
   end
 
   it 'can make versions of resources with UUID primary keys' do
@@ -330,7 +330,7 @@ class TestModel < Minitest::Test
     assert_equal book.versions.last.title, original_title
     assert_equal book.at(datetime).title, original_title
     book.destroy!
-    untrashed_book = BookVersion.trashed.find_by(book_id: book_id).untrash!
+    untrashed_book = BookVersion.trashed.find_by(hoardable_source_id: book_id).untrash!
     assert_equal untrashed_book.title, new_title
     assert_equal untrashed_book.id, book_id
   end


### PR DESCRIPTION
The `foreign_key` on the temporal `versions` tables used to derive their name from the i18n singularized table naming. This is now being changed universally to `hoardable_source_id`. The intent is to never leave room for conflict of foreign keys for existing relationships. This can be upgraded for existing versions tables by renaming the columns from their i18n model name derived column names to `hoardable_source_id`, i.e.:

```
rename_column :post_versions, :post_id, :hoardable_source_id
```