### PR TITLE
Introduce `Hoardable.at`, `.hoardable`, `has_many_hoardable`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,3 +16,6 @@ Metrics/BlockLength:
 
 Style/DocumentDynamicEvalDefinition:
   Enabled: false
+
+Naming/PredicateName:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 - Stability is coming.
 
+## [0.9.0] - 2022-10-02
+
+- **Breaking Change** - `Hoardable.return_everything` was removed in favor of the newly added
+  `Hoardable.at`.
+
 ## [0.8.0] - 2022-10-01
 
 - **Breaking Change** - Due to the performance benefit of using `insert` for database injection of

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ _Note:_ If you are on Rails 6.1, you might want to set `config.active_record.sch
 in `application.rb`, so that the enum type is captured in your schema dump. This is not required in
 Rails 7.
 
+_Note:_ Creating an inherited table does not copy over the indexes from the parent table. If you
+need to query versions often, you should add appropriate indexes to the `_versions` tables.
+
 ## Usage
 
 ### Overview
@@ -105,7 +108,7 @@ Each `PostVersion` has access to the same attributes, relationships, and other m
 
 If you ever need to revert to a specific version, you can call `version.revert!` on it.
 
-``` ruby
+```ruby
 post = Post.create!(title: "Title")
 post.update!(title: "Whoops")
 post.reload.versions.last.revert!
@@ -113,7 +116,7 @@ post.title # => "Title"
 ```
 
 If you would like to untrash a specific version, you can call `version.untrash!` on it. This will
-re-insert the model in the parent class’s table with it’s original primary key.
+re-insert the model in the parent class’s table with the original primary key.
 
 ```ruby
 post = Post.create!(title: "Title")
@@ -145,16 +148,44 @@ PostVersion.at(1.day.ago).find_by(hoardable_source_id: post.id) # => #<PostVersi
 
 The source model class also has an `.at` method:
 
-``` ruby
+```ruby
 Post.at(1.day.ago) # => [#<Post>, #<Post>]
 ```
 
-This will return an ActiveRecord scoped query of all `Posts` and `PostVersions` that were valid at
-that time, all cast as instances of `Post`.
+This will return an ActiveRecord scoped query of all `Post` and `PostVersion` records that were
+valid at that time, all cast as instances of `Post`.
 
-_Note:_ A `Version` is not created upon initial parent model creation. To accurately track the
-beginning of the first temporal period, you will need to ensure the source model table has a
-`created_at` timestamp column.
+There is also an `at` method on `Hoardable` itself. This allows you query multiple resources at a
+certain time in history.
+
+```ruby
+post = Post.create!(title: 'Title')
+comment1 = post.comments.create!(body: 'Comment')
+comment2 = post.comments.create!(body: 'Comment')
+datetime = DateTime.current
+comment2.destroy!
+post.update!(title: 'New Title')
+post_id = post.id # 1
+Hoardable.at(datetime) do
+  post = Post.hoardable.find(post_id)
+  post.title # => 'Title'
+  post.comments.size # => 1
+  post.id # => 2
+  post.version? # => true
+  post.hoardable_source_id # => 1
+end
+```
+
+There are some additional things to point out above. Firstly, it is important to note that the final
+`post.id` yields a different value than the originally created `Post`. This is because the `post`
+within the `#at` block is actually a temporal version, but it has been reified as a `Post` for the
+purposes of your business logic. Don’t fret - you will not be able to commit any updates to the
+version, even though it is masquerading as a `Post`.
+
+If you are ever unsure if a Hoardable record is a "source" or a "version", you can be sure with
+`version?`. If you want to get the true original source record ID, you can call
+`hoardable_source_id`. Finally, if you prepend `.hoardable` to a `.find` call on the source model
+class, you can find the relevant source or version record using the original source record id.
 
 By default, `hoardable` will keep copies of records you have destroyed. You can query them
 specifically with:
@@ -162,10 +193,12 @@ specifically with:
 ```ruby
 PostVersion.trashed
 Post.version_class.trashed # <- same thing as above
+PostVersion.trashed.first.trashed? # <- true
 ```
 
-_Note:_ Creating an inherited table does not copy over the indexes from the parent table. If you
-need to query versions often, you should add appropriate indexes to the `_versions` tables.
+_Note:_ A `Version` is not created upon initial parent model creation. To accurately track the
+beginning of the first temporal period, you will need to ensure the source model table has a
+`created_at` timestamp column.
 
 ### Tracking Contextual Data
 
@@ -269,7 +302,6 @@ The configurable options are:
 Hoardable.enabled # => default true
 Hoardable.version_updates # => default true
 Hoardable.save_trash # => default true
-Hoardable.return_everything # => default false
 ```
 
 `Hoardable.enabled` controls whether versions will be ever be created.
@@ -278,10 +310,6 @@ Hoardable.return_everything # => default false
 
 `Hoardable.save_trash` controls whether to create versions upon record deletion. When this is set to
 `false`, all versions of a record will be deleted when the record is destroyed.
-
-`Hoardable.return_everything` controls whether to include versions when doing queries for source
-models. This is typically only useful to set around a block, as explained below in
-[Relationships](#relationships).
 
 If you would like to temporarily set a config setting, you can use `Hoardable.with`:
 
@@ -348,22 +376,6 @@ class Post < ActiveRecord::Base
       .find_each(&:untrash!)
   end
 end
-```
-
-If there are models that might be related to versions that are trashed or otherwise, and/or might be
-trashed themselves, you can bypass the inherited tables query handling altogether by using the
-`return_everything` configuration variable in `Hoardable.with`. This will ensure that you always see
-all records, including update and trashed versions.
-
-```ruby
-post.destroy!
-
-Hoardable.with(return_everything: true) do
-  post = Post.find(post.id) # returns the trashed post as if it was not
-  post.comments # returns the trashed comments as well
-end
-
-post.reload # raises ActiveRecord::RecordNotFound
 ```
 
 ## Gem Comparison

--- a/lib/generators/hoardable/initializer_generator.rb
+++ b/lib/generators/hoardable/initializer_generator.rb
@@ -14,7 +14,6 @@ module Hoardable
           # Hoardable.enabled = true
           # Hoardable.version_updates = true
           # Hoardable.save_trash = true
-          # Hoardable.return_everything = true
         TEXT
       )
     end

--- a/lib/hoardable.rb
+++ b/lib/hoardable.rb
@@ -2,7 +2,7 @@
 
 require_relative 'hoardable/version'
 require_relative 'hoardable/hoardable'
-require_relative 'hoardable/tableoid'
+require_relative 'hoardable/scopes'
 require_relative 'hoardable/error'
 require_relative 'hoardable/database_client'
 require_relative 'hoardable/source_model'

--- a/lib/hoardable/associations.rb
+++ b/lib/hoardable/associations.rb
@@ -19,9 +19,7 @@ module Hoardable
       def hoardable_scope
         if Hoardable.instance_variable_get('@at') &&
            (hoardable_source_id = @association.owner.hoardable_source_id)
-          @association.scope.rewhere(
-            @association.reflection.foreign_key => hoardable_source_id
-          )
+          @association.scope.rewhere(@association.reflection.foreign_key => hoardable_source_id)
         else
           @association.scope
         end

--- a/lib/hoardable/associations.rb
+++ b/lib/hoardable/associations.rb
@@ -9,7 +9,7 @@ module Hoardable
 
     # An +ActiveRecord+ extension that allows looking up {VersionModel}s by +hoardable_source_id+ as
     # if they were {SourceModel} ids.
-    module Scope
+    module HasManyScope
       def scope
         @scope ||= hoardable_scope
       end
@@ -27,6 +27,7 @@ module Hoardable
         end
       end
     end
+    private_constant :HasManyScope
 
     class_methods do
       # A wrapper for +ActiveRecord+’s +belongs_to+ that allows for falling back to the most recent
@@ -54,7 +55,7 @@ module Hoardable
       # A wrapper for +ActiveRecord+’s +has_many+ that allows for finding temporal versions of a
       # versioned record that is cast as a {SourceModel}, when doing a {Hoardable#at} query.
       def has_many_versionable(name, scope = nil, **options)
-        has_many(name, scope, **options) { include Scope }
+        has_many(name, scope, **options) { include HasManyScope }
       end
     end
   end

--- a/lib/hoardable/associations.rb
+++ b/lib/hoardable/associations.rb
@@ -8,7 +8,7 @@ module Hoardable
     extend ActiveSupport::Concern
 
     # An +ActiveRecord+ extension that allows looking up {VersionModel}s by +hoardable_source_id+ as
-    # if they were {SourceModel} ids.
+    # if they were {SourceModel}s.
     module HasManyScope
       def scope
         @scope ||= hoardable_scope
@@ -51,8 +51,8 @@ module Hoardable
       end
 
       # A wrapper for +ActiveRecord+’s +has_many+ that allows for finding temporal versions of a
-      # versioned record that is cast as a {SourceModel}, when doing a {Hoardable#at} query.
-      def has_many_versionable(name, scope = nil, **options)
+      # record cast as instances of the {SourceModel}, when doing a {Hoardable#at} query.
+      def has_many_hoardable(name, scope = nil, **options)
         has_many(name, scope, **options) { include HasManyScope }
       end
     end

--- a/lib/hoardable/database_client.rb
+++ b/lib/hoardable/database_client.rb
@@ -12,6 +12,10 @@ module Hoardable
 
     delegate :version_class, to: :source_record
 
+    def prevent_saving_if_actually_a_version
+      raise Error, 'You cannot save a Hoardable Model that is actually already a version' if source_record.version?
+    end
+
     def insert_hoardable_version(operation, &block)
       version = version_class.insert(initialize_version_attributes(operation), returning: :id)
       version_id = version[0]['id']

--- a/lib/hoardable/database_client.rb
+++ b/lib/hoardable/database_client.rb
@@ -27,6 +27,15 @@ module Hoardable
       Thread.current[:hoardable_event_uuid] ||= ActiveRecord::Base.connection.query('SELECT gen_random_uuid();')[0][0]
     end
 
+    def hoardable_version_source_id
+      @hoardable_version_source_id ||= query_hoardable_version_source_id
+    end
+
+    def query_hoardable_version_source_id
+      primary_key = source_record.class.primary_key
+      version_class.where(primary_key => source_record.read_attribute(primary_key)).pluck('hoardable_source_id')[0]
+    end
+
     def initialize_version_attributes(operation)
       source_record.attributes_before_type_cast.without('id').merge(
         source_record.changes.transform_values { |h| h[0] },

--- a/lib/hoardable/hoardable.rb
+++ b/lib/hoardable/hoardable.rb
@@ -75,6 +75,13 @@ module Hoardable
       @context = current_context
     end
 
+    def at(datetime)
+      @at = datetime
+      yield
+    ensure
+      @at = nil
+    end
+
     # @!visibility private
     def logger
       @logger ||= ActiveSupport::TaggedLogging.new(Logger.new($stdout))

--- a/lib/hoardable/hoardable.rb
+++ b/lib/hoardable/hoardable.rb
@@ -75,10 +75,10 @@ module Hoardable
       @context = current_context
     end
 
-    # This is a general use method for setting {file:README.md#tracking-contextual-data Contextual
-    # Data} or {file:README.md#configuration Configuration} around a block.
+    # Allows performing a query for record states at a certain time. Returned {SourceModel}
+    # instances within the block may be {SourceModel} or {VersionModel} records.
     #
-    # @param hash [Hash] config and contextual data to set within a block
+    # @param datetime [DateTime, Time] the datetime or time to temporally query records at
     def at(datetime)
       @at = datetime
       yield

--- a/lib/hoardable/hoardable.rb
+++ b/lib/hoardable/hoardable.rb
@@ -8,7 +8,7 @@ module Hoardable
 
   # Symbols for use with setting {Hoardable} configuration. See {file:README.md#configuration
   # README} for more.
-  CONFIG_KEYS = %i[enabled version_updates save_trash return_everything warn_on_missing_created_at_column].freeze
+  CONFIG_KEYS = %i[enabled version_updates save_trash warn_on_missing_created_at_column].freeze
 
   VERSION_CLASS_SUFFIX = 'Version'
   private_constant :VERSION_CLASS_SUFFIX
@@ -36,7 +36,7 @@ module Hoardable
 
   @context = {}
   @config = CONFIG_KEYS.to_h do |key|
-    [key, key != :return_everything]
+    [key, true]
   end
 
   class << self
@@ -75,6 +75,10 @@ module Hoardable
       @context = current_context
     end
 
+    # This is a general use method for setting {file:README.md#tracking-contextual-data Contextual
+    # Data} or {file:README.md#configuration Configuration} around a block.
+    #
+    # @param hash [Hash] config and contextual data to set within a block
     def at(datetime)
       @at = datetime
       yield

--- a/lib/hoardable/scopes.rb
+++ b/lib/hoardable/scopes.rb
@@ -20,12 +20,10 @@ module Hoardable
 
       # By default {Hoardable} only returns instances of the parent table, and not the +versions+ in
       # the inherited table. This can be bypassed by using the {.include_versions} scope or wrapping
-      # the code in a `Hoardable.with(return_everything: true)` block.
+      # the code in a `Hoardable.at(datetime)` block.
       default_scope do
         if (hoardable_at = Hoardable.instance_variable_get('@at'))
           at(hoardable_at)
-        elsif hoardable_config[:return_everything]
-          where(nil)
         else
           exclude_versions
         end

--- a/lib/hoardable/version.rb
+++ b/lib/hoardable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hoardable
-  VERSION = '0.8.1'
+  VERSION = '0.9.0'
 end

--- a/lib/hoardable/version_model.rb
+++ b/lib/hoardable/version_model.rb
@@ -113,17 +113,16 @@ module Hoardable
       _data&.dig('changes')
     end
 
-    # Returns the foreign reference that represents the source model of the version.
-    def hoardable_source_foreign_id
-      @hoardable_source_foreign_id ||= public_send(:hoardable_source_id)
+    def hoardable_source_id
+      read_attribute('hoardable_source_id')
     end
 
     private
 
     def insert_untrashed_source
       superscope = self.class.superclass.unscoped
-      superscope.insert(hoardable_source_attributes.merge('id' => hoardable_source_foreign_id))
-      superscope.find(hoardable_source_foreign_id)
+      superscope.insert(hoardable_source_attributes.merge('id' => hoardable_source_id))
+      superscope.find(hoardable_source_id)
     end
 
     def hoardable_source_attributes

--- a/lib/hoardable/version_model.rb
+++ b/lib/hoardable/version_model.rb
@@ -113,6 +113,7 @@ module Hoardable
       _data&.dig('changes')
     end
 
+    # Returns the ID of the {SourceModel} that created this {VersionModel}
     def hoardable_source_id
       read_attribute('hoardable_source_id')
     end

--- a/sig/hoardable.rbs
+++ b/sig/hoardable.rbs
@@ -101,7 +101,7 @@ module Hoardable
 
   module Associations
     def belongs_to_trashable: (untyped name, ?nil scope, **untyped) -> untyped
-    def has_many_versionable: (untyped name, ?nil scope, **untyped) -> untyped
+    def has_many_hoardable: (untyped name, ?nil scope, **untyped) -> untyped
 
     module HasManyScope
       @scope: untyped

--- a/sig/hoardable.rbs
+++ b/sig/hoardable.rbs
@@ -1,7 +1,7 @@
 module Hoardable
   VERSION: String
   DATA_KEYS: [:meta, :whodunit, :note, :event_uuid]
-  CONFIG_KEYS: [:enabled, :version_updates, :save_trash, :return_everything, :warn_on_missing_created_at_column]
+  CONFIG_KEYS: [:enabled, :version_updates, :save_trash, :warn_on_missing_created_at_column]
   VERSION_CLASS_SUFFIX: String
   VERSION_TABLE_SUFFIX: String
   DURING_QUERY: String
@@ -10,12 +10,14 @@ module Hoardable
   HOARDABLE_VERSION_UPDATES: ^(untyped) -> untyped
   self.@context: Hash[untyped, untyped]
   self.@config: untyped
+  self.@at: nil
   self.@logger: untyped
 
   def self.with: (untyped hash) -> untyped
+  def self.at: (untyped datetime) -> untyped
   def self.logger: -> untyped
 
-  module Tableoid
+  module Scopes
     TABLEOID_AREL_CONDITIONS: Proc
 
     private
@@ -29,10 +31,15 @@ module Hoardable
   end
 
   class DatabaseClient
-    attr_reader source_model: SourceModel
-    def initialize: (SourceModel source_model) -> void
+    @hoardable_version_source_id: untyped
+
+    attr_reader source_record: SourceModel
+    def initialize: (SourceModel source_record) -> void
+    def prevent_saving_if_actually_a_version: -> nil
     def insert_hoardable_version: (untyped operation) -> untyped
     def find_or_initialize_hoardable_event_uuid: -> untyped
+    def hoardable_version_source_id: -> untyped
+    def query_hoardable_version_source_id: -> untyped
     def initialize_version_attributes: (untyped operation) -> untyped
     def initialize_temporal_range: -> Range
     def initialize_hoardable_data: -> untyped
@@ -44,29 +51,35 @@ module Hoardable
   end
 
   module SourceModel
-    include Tableoid
+    include Scopes
     @hoardable_client: DatabaseClient
 
     attr_reader hoardable_version: untyped
     def trashed?: -> untyped
+    def version?: -> untyped
     def at: (untyped datetime) -> SourceModel
     def revert_to!: (untyped datetime) -> SourceModel?
+    def hoardable_source_id: -> untyped
 
     private
     def hoardable_client: -> DatabaseClient
 
     public
     def version_class: -> untyped
+    def hoardable: -> untyped
+
+    module FinderMethods
+      def find_one: (untyped id) -> untyped
+    end
   end
 
   module VersionModel
-    @hoardable_source_foreign_id: untyped
     @hoardable_source_attributes: untyped
 
     def revert!: -> untyped
     def untrash!: -> untyped
     def changes: -> untyped
-    def hoardable_source_foreign_id: -> untyped
+    def hoardable_source_id: -> untyped
 
     private
     def insert_untrashed_source: -> untyped
@@ -88,6 +101,17 @@ module Hoardable
 
   module Associations
     def belongs_to_trashable: (untyped name, ?nil scope, **untyped) -> untyped
+    def has_many_versionable: (untyped name, ?nil scope, **untyped) -> untyped
+
+    module HasManyScope
+      @scope: untyped
+      @association: bot
+
+      def scope: -> untyped
+
+      private
+      def hoardable_scope: -> untyped
+    end
   end
 
   class MigrationGenerator
@@ -97,5 +121,9 @@ module Hoardable
     def foreign_key_type: -> String
     def migration_template_name: -> String
     def singularized_table_name: -> untyped
+  end
+
+  class InitializerGenerator
+    def create_initializer_file: -> untyped
   end
 end

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -3,7 +3,7 @@
 class Post < ActiveRecord::Base
   include Hoardable::Model
   belongs_to :user
-  has_many_versionable :comments, dependent: :destroy
+  has_many_hoardable :comments, dependent: :destroy
   attr_reader :_hoardable_operation, :reverted, :untrashed, :hoardable_version_id
 
   after_versioned do

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -3,7 +3,7 @@
 class Post < ActiveRecord::Base
   include Hoardable::Model
   belongs_to :user
-  has_many :comments, dependent: :destroy
+  has_many_versionable :comments, dependent: :destroy
   attr_reader :_hoardable_operation, :reverted, :untrashed, :hoardable_version_id
 
   after_versioned do


### PR DESCRIPTION
`Hoardable.at` provides a high-level block form of doing cross resource temporal lookups. This replaces `Hoardable.return_everything` as a more useful and pointed tool.

`has_many_hoardable` provides a way to define an extended `has_many` association that can hook into into `Hoardable.at`'s temporal awareness.

A `.hoardable` scope is added to `Hoardable::Model`s that allow for finding the a relevant version or source record by providing just the source record's ID.