### PR TITLE
`has_many through` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ of that model. As we continue our example from above:
 ```
 $ irb
 >> Post
-=> Post(id: integer, body: text, user_id: integer, created_at: datetime)
+=> Post(id: integer, body: text, user_id: integer, created_at: datetime, hoardable_id: integer)
 >> PostVersion
-=> PostVersion(id: integer, body: text, user_id: integer, created_at: datetime, _data: jsonb, _during: tsrange, hoardable_source_id: integer)
+=> PostVersion(id: integer, body: text, user_id: integer, created_at: datetime, hoardable_id: integer, _data: jsonb, _during: tsrange)
 ```
 
 A `Post` now `has_many :versions`. With the default configuration, whenever an update and deletion
@@ -144,7 +144,7 @@ If you want to look-up the version of a record at a specific time, you can use t
 ```ruby
 post.at(1.day.ago) # => #<PostVersion>
 # or you can use the scope on the version model class
-PostVersion.at(1.day.ago).find_by(hoardable_source_id: post.id) # => #<PostVersion>
+PostVersion.at(1.day.ago).find_by(hoardable_id: post.id) # => #<PostVersion>
 ```
 
 The source model class also has an `.at` method:
@@ -357,7 +357,7 @@ Hoardable.at(datetime) do
   post.comments.size # => 2
   post.id # => 2
   post.version? # => true
-  post.hoardable_source_id # => 1
+  post.hoardable_id # => 1
 end
 ```
 
@@ -370,7 +370,7 @@ version, even though it is masquerading as a `Post`.
 
 If you are ever unsure if a Hoardable record is a "source" or a "version", you can be sure by
 calling `version?` on it. If you want to get the true original source record ID, you can call
-`hoardable_source_id`. 
+`hoardable_id`. 
 
 Sometimes you’ll trash something that `has_many :children, dependent: :destroy` and want
 to untrash everything in a similar dependent manner. Whenever a hoardable version is created in a

--- a/lib/generators/hoardable/templates/install.rb.erb
+++ b/lib/generators/hoardable/templates/install.rb.erb
@@ -13,12 +13,27 @@ class InstallHoardable < ActiveRecord::Migration[<%= ActiveRecord::Migration.cur
           END IF;
         END
         $$;
+        CREATE OR REPLACE FUNCTION hoardable_source_set_id() RETURNS trigger
+          LANGUAGE plpgsql AS
+        $$BEGIN
+          NEW.hoardable_id = NEW.id;
+          RETURN NEW;
+        END;$$;
         CREATE OR REPLACE FUNCTION hoardable_version_prevent_update() RETURNS trigger
           LANGUAGE plpgsql AS
         $$BEGIN
           RAISE EXCEPTION 'updating a version is not allowed';
           RETURN NEW;
         END;$$;
+      SQL
+    )
+  end
+  def down
+    execute(
+      <<~SQL
+        DROP TYPE IF EXISTS hoardable_operation;
+        DROP FUNCTION IF EXISTS hoardable_version_prevent_update();
+        DROP FUNCTION IF EXISTS hoardable_source_set_id();
       SQL
     )
   end

--- a/lib/generators/hoardable/templates/migration.rb.erb
+++ b/lib/generators/hoardable/templates/migration.rb.erb
@@ -2,12 +2,13 @@
 
 class Create<%= class_name.singularize.delete(':') %>Versions < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
   def change
+    add_column :<%= table_name %>, :hoardable_id, :<%= foreign_key_type %>
+    add_index :<%= table_name %>, :hoardable_id
     create_table :<%= singularized_table_name %>_versions, id: false, options: 'INHERITS (<%= table_name %>)' do |t|
       t.jsonb :_data
       t.tsrange :_during, null: false
       t.uuid :_event_uuid, null: false, index: true
       t.column :_operation, :hoardable_operation, null: false, index: true
-      t.<%= foreign_key_type %> :hoardable_source_id, null: false, index: true
     end
     reversible do |dir|
       dir.up do
@@ -16,6 +17,9 @@ class Create<%= class_name.singularize.delete(':') %>Versions < ActiveRecord::Mi
             CREATE TRIGGER <%= singularized_table_name %>_versions_prevent_update
               BEFORE UPDATE ON <%= singularized_table_name %>_versions FOR EACH ROW
               EXECUTE PROCEDURE hoardable_version_prevent_update();
+            CREATE TRIGGER <%= table_name %>_set_hoardable_id
+              BEFORE INSERT ON <%= table_name %> FOR EACH ROW
+              EXECUTE PROCEDURE hoardable_source_set_id();
           SQL
         )
       end
@@ -24,6 +28,8 @@ class Create<%= class_name.singularize.delete(':') %>Versions < ActiveRecord::Mi
           <<~SQL
             DROP TRIGGER <%= singularized_table_name %>_versions_prevent_update
               ON <%= singularized_table_name %>_versions;
+            DROP TRIGGER <%= table_name %>_set_hoardable_id
+              ON <%= table_name %>;
           SQL
         )
       end
@@ -31,7 +37,7 @@ class Create<%= class_name.singularize.delete(':') %>Versions < ActiveRecord::Mi
     add_index(:<%= singularized_table_name %>_versions, :id, unique: true)
     add_index(
       :<%= singularized_table_name %>_versions,
-      %i[_during hoardable_source_id],
+      %i[_during hoardable_id],
       name: 'idx_<%= singularized_table_name %>_versions_temporally'
     )
   end

--- a/lib/hoardable/belongs_to.rb
+++ b/lib/hoardable/belongs_to.rb
@@ -21,7 +21,7 @@ module Hoardable
         define_method("trashed_#{name}") do
           source_reflection = reflections[name.to_s]
           source_reflection.version_class.trashed.only_most_recent.find_by(
-            hoardable_source_id: source_reflection.foreign_key
+            hoardable_id: source_reflection.foreign_key
           )
         end
 

--- a/lib/hoardable/database_client.rb
+++ b/lib/hoardable/database_client.rb
@@ -23,20 +23,11 @@ module Hoardable
       Thread.current[:hoardable_event_uuid] ||= ActiveRecord::Base.connection.query('SELECT gen_random_uuid();')[0][0]
     end
 
-    def hoardable_version_source_id
-      @hoardable_version_source_id ||= query_hoardable_version_source_id
-    end
-
-    def query_hoardable_version_source_id
-      primary_key = source_record.class.primary_key
-      version_class.where(primary_key => source_record.read_attribute(primary_key)).pluck('hoardable_source_id')[0]
-    end
-
     def initialize_version_attributes(operation)
       source_record.attributes_before_type_cast.without('id').merge(
         source_record.changes.transform_values { |h| h[0] },
         {
-          'hoardable_source_id' => source_record.id,
+          'hoardable_id' => source_record.id,
           '_event_uuid' => find_or_initialize_hoardable_event_uuid,
           '_operation' => operation,
           '_data' => initialize_hoardable_data.merge(changes: source_record.changes),

--- a/lib/hoardable/finder_methods.rb
+++ b/lib/hoardable/finder_methods.rb
@@ -7,18 +7,18 @@ module Hoardable
   # with the class method +hoardable+.
   module FinderMethods
     def find_one(id)
-      super(hoardable_source_ids([id])[0])
+      super(hoardable_ids([id])[0])
     end
 
     def find_some(ids)
-      super(hoardable_source_ids(ids))
+      super(hoardable_ids(ids))
     end
 
     private
 
-    def hoardable_source_ids(ids)
+    def hoardable_ids(ids)
       ids.map do |id|
-        version_class.where(hoardable_source_id: id).select(primary_key).ids[0] || id
+        version_class.where(hoardable_id: id).select(primary_key).ids[0] || id
       end
     end
   end

--- a/lib/hoardable/has_many.rb
+++ b/lib/hoardable/has_many.rb
@@ -5,7 +5,7 @@ module Hoardable
   module HasMany
     extend ActiveSupport::Concern
 
-    # An +ActiveRecord+ extension that allows looking up {VersionModel}s by +hoardable_source_id+ as
+    # An +ActiveRecord+ extension that allows looking up {VersionModel}s by +hoardable_id+ as
     # if they were {SourceModel}s when using {Hoardable#at}.
     module HasManyExtension
       def scope
@@ -16,8 +16,8 @@ module Hoardable
 
       def hoardable_scope
         if Hoardable.instance_variable_get('@at') &&
-           (hoardable_source_id = @association.owner.hoardable_source_id)
-          @association.scope.rewhere(@association.reflection.foreign_key => hoardable_source_id)
+           (hoardable_id = @association.owner.hoardable_id)
+          @association.scope.rewhere(@association.reflection.foreign_key => hoardable_id)
         else
           @association.scope
         end

--- a/lib/hoardable/has_many.rb
+++ b/lib/hoardable/has_many.rb
@@ -17,6 +17,9 @@ module Hoardable
       def hoardable_scope
         if Hoardable.instance_variable_get('@at') &&
            (hoardable_id = @association.owner.hoardable_id)
+          if @association.reflection.is_a?(ActiveRecord::Reflection::ThroughReflection)
+            @association.reflection.source_reflection.instance_variable_set('@active_record_primary_key', 'hoardable_id')
+          end
           @association.scope.rewhere(@association.reflection.foreign_key => hoardable_id)
         else
           @association.scope

--- a/lib/hoardable/has_many.rb
+++ b/lib/hoardable/has_many.rb
@@ -15,10 +15,11 @@ module Hoardable
       private
 
       def hoardable_scope
-        if Hoardable.instance_variable_get('@at') &&
-           (hoardable_id = @association.owner.hoardable_id)
+        if Hoardable.instance_variable_get('@at') && (hoardable_id = @association.owner.hoardable_id)
           if @association.reflection.is_a?(ActiveRecord::Reflection::ThroughReflection)
-            @association.reflection.source_reflection.instance_variable_set('@active_record_primary_key', 'hoardable_id')
+            @association.reflection.source_reflection.instance_variable_set(
+              '@active_record_primary_key', 'hoardable_id'
+            )
           end
           @association.scope.rewhere(@association.reflection.foreign_key => hoardable_id)
         else

--- a/lib/hoardable/scopes.rb
+++ b/lib/hoardable/scopes.rb
@@ -65,7 +65,7 @@ module Hoardable
         include_versions.where(id: version_class.at(datetime).select('id')).or(
           exclude_versions
             .where("#{table_name}.created_at < ?", datetime)
-            .where.not(id: version_class.select(:hoardable_source_id).where(DURING_QUERY, datetime))
+            .where.not(id: version_class.select(:hoardable_id).where(DURING_QUERY, datetime))
         ).hoardable
       }
     end

--- a/lib/hoardable/source_model.rb
+++ b/lib/hoardable/source_model.rb
@@ -51,7 +51,7 @@ module Hoardable
         dependent: nil,
         class_name: version_class.to_s,
         inverse_of: :hoardable_source,
-        foreign_key: :hoardable_source_id
+        foreign_key: :hoardable_id
       )
     end
 
@@ -60,7 +60,7 @@ module Hoardable
     #
     # @return [Boolean]
     def trashed?
-      versions.trashed.only_most_recent.first&.hoardable_source_id == id
+      !self.class.exists?(id: id)
     end
 
     # Returns a boolean of whether the record is actually a +version+ cast as an instance of the
@@ -68,7 +68,7 @@ module Hoardable
     #
     # @return [Boolean]
     def version?
-      !!hoardable_client.hoardable_version_source_id
+      hoardable_id != id
     end
 
     # Returns the +version+ at the supplied +datetime+ or +time+, or +self+ if there is none.
@@ -96,15 +96,6 @@ module Hoardable
       return unless (version = at(datetime))
 
       version.is_a?(version_class) ? version.revert! : self
-    end
-
-    # Returns the +hoardable_source_id+ that represents the original {SourceModel} record’s ID. Will
-    # return nil if the current {SourceModel} record is not an instance of a {VersionModel} cast as
-    # {SourceModel}.
-    #
-    # @return [Integer, nil]
-    def hoardable_source_id
-      hoardable_client.hoardable_version_source_id || id
     end
 
     delegate :version_class, to: :class

--- a/lib/hoardable/source_model.rb
+++ b/lib/hoardable/source_model.rb
@@ -98,6 +98,10 @@ module Hoardable
       version.is_a?(version_class) ? version.revert! : self
     end
 
+    def hoardable_id
+      read_attribute('hoardable_id')
+    end
+
     delegate :version_class, to: :class
 
     private

--- a/lib/hoardable/version.rb
+++ b/lib/hoardable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hoardable
-  VERSION = '0.11.0'
+  VERSION = '0.12.0'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,3 +35,5 @@ Rails.initialize!
 
 require_relative 'support/models'
 require_relative 'support/database'
+
+ActiveRecord::Base.descendants.each(&:reset_column_information)

--- a/test/test_migration_generator.rb
+++ b/test/test_migration_generator.rb
@@ -11,14 +11,14 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
   def shared_post_assertions
     assert_migration 'db/migrate/create_post_versions.rb' do |migration|
       assert_match(/create_table :post_versions/, migration)
-      assert_match(/t.bigint :hoardable_source_id/, migration)
+      assert_match(/:hoardable_id, :bigint/, migration)
     end
   end
 
   def shared_book_assertions(foreign_key_type = 'uuid')
     assert_migration 'db/migrate/create_book_versions.rb' do |migration|
       assert_match(/create_table :book_versions/, migration)
-      assert_match("t.#{foreign_key_type} :hoardable_source_id", migration)
+      assert_match(":hoardable_id, :#{foreign_key_type}", migration)
     end
   end
 
@@ -56,7 +56,7 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     run_generator ['ActionText::RichText']
     assert_migration 'db/migrate/create_action_text_rich_text_versions.rb' do |migration|
       assert_match(/create_table :action_text_rich_text_versions/, migration)
-      assert_match('t.bigint :hoardable_source_id', migration)
+      assert_match(':hoardable_id, :bigint', migration)
     end
   end
 end

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -75,14 +75,14 @@ class TestModel < Minitest::Test
     post.destroy!
     datetime4 = DateTime.now
     assert_equal post.at(datetime1).title, 'Headline'
-    assert_equal PostVersion.at(datetime1).find_by(hoardable_source_id: post.id).title, 'Headline'
+    assert_equal PostVersion.at(datetime1).find_by(hoardable_id: post.id).title, 'Headline'
     assert_equal post.at(datetime2).title, 'New Headline'
-    assert_equal PostVersion.at(datetime2).find_by(hoardable_source_id: post.id).title, 'New Headline'
+    assert_equal PostVersion.at(datetime2).find_by(hoardable_id: post.id).title, 'New Headline'
     assert_equal post.at(datetime3).title, 'Revert'
-    assert_equal PostVersion.at(datetime3).find_by(hoardable_source_id: post.id).title, 'Revert'
+    assert_equal PostVersion.at(datetime3).find_by(hoardable_id: post.id).title, 'Revert'
     assert_equal post.trashed?, true
     assert_equal post.at(datetime4).title, 'Revert'
-    assert_nil PostVersion.at(datetime4).find_by(hoardable_source_id: post.id)
+    assert_nil PostVersion.at(datetime4).find_by(hoardable_id: post.id)
   end
 
   it 'can revert to version at a datetime' do
@@ -133,7 +133,7 @@ class TestModel < Minitest::Test
   end
 
   it 'can be reverted from previous version' do
-    attributes = post.attributes.without('updated_at')
+    attributes = post.reload.attributes.without('updated_at')
     update_post
     version = post.versions.first
     version.revert!
@@ -143,12 +143,12 @@ class TestModel < Minitest::Test
 
   it 'creates a version on deletion and can be untrashed' do
     post_id = post.id
-    attributes = post.attributes.without('updated_at')
+    attributes = post.reload.attributes.without('updated_at')
     post.destroy!
     assert post.trashed?
     assert_raises(ActiveRecord::RecordNotFound) { Post.find(post.id) }
     version = PostVersion.last
-    assert_equal version.hoardable_source_id, post_id
+    assert_equal version.hoardable_id, post_id
     untrashed_post = version.untrash!
     assert_equal untrashed_post.attributes.without('updated_at'), attributes
     refute post.reload.trashed?
@@ -311,7 +311,7 @@ class TestModel < Minitest::Test
     post.comments.create!(body: 'Comment 1')
     post.comments.create!(body: 'Comment 2')
     post.destroy!
-    PostVersion.trashed.find_by(hoardable_source_id: post.id)
+    PostVersion.trashed.find_by(hoardable_id: post.id)
   end
 
   it 'recursively creates trashed versions with shared event_uuid' do
@@ -337,8 +337,8 @@ class TestModel < Minitest::Test
   end
 
   it 'creates a version class with a foreign key type that matches the primary key' do
-    assert_equal Post.version_class.columns.find { |col| col.name == 'hoardable_source_id' }.sql_type, 'bigint'
-    assert_equal Book.version_class.columns.find { |col| col.name == 'hoardable_source_id' }.sql_type, 'uuid'
+    assert_equal Post.version_class.columns.find { |col| col.name == 'hoardable_id' }.sql_type, 'bigint'
+    assert_equal Book.version_class.columns.find { |col| col.name == 'hoardable_id' }.sql_type, 'uuid'
   end
 
   it 'can make versions of resources with UUID primary keys' do
@@ -351,7 +351,7 @@ class TestModel < Minitest::Test
     assert_equal book.versions.last.title, original_title
     assert_equal book.at(datetime).title, original_title
     book.destroy!
-    untrashed_book = BookVersion.trashed.find_by(hoardable_source_id: book_id).untrash!
+    untrashed_book = BookVersion.trashed.find_by(hoardable_id: book_id).untrash!
     assert_equal untrashed_book.title, new_title
     assert_equal untrashed_book.id, book_id
   end
@@ -500,11 +500,11 @@ class TestModel < Minitest::Test
         [comment1.id, comment3.id, comment2.versions.last.id]
       )
       assert_equal(
-        post.reload.comments.map(&:hoardable_source_id),
+        post.reload.comments.map(&:hoardable_id),
         [comment1.id, comment3.id, comment2.id]
       )
     end
-    assert_equal(post.reload.comment_ids, post.reload.comments.map(&:hoardable_source_id))
+    assert_equal(post.reload.comment_ids, post.reload.comments.map(&:hoardable_id))
   end
 
   it 'can return hoardable results with has one relationship' do

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -467,7 +467,6 @@ class TestModel < Minitest::Test
   end
 
   it 'can return hoardable records via a has many through relationship' do
-    skip
     post = Post.create!(user: user, title: 'Title')
     comment = post.comments.create!(body: 'Comment')
     comment.likes.create!
@@ -483,7 +482,6 @@ class TestModel < Minitest::Test
       comment = post.comments.first
       assert_equal Like.all.size, 2
       assert_equal comment.likes.size, 2
-      # TODO: this does not work yet
       assert_equal post.likes.size, 2
     end
   end


### PR DESCRIPTION
This is made possible due to a schema change of moving what was once called `hoardable_source_id` on the versions table up to `hoardable_id` on the source model table. `hoardable_id` is set to `id` with a trigger on source model insertion and when a version is inserted, even though a new ID is generated, `hoardable_id` will remain as a stable reference to the original source record ID. Because the column is on both source and version tables, it makes queries across the parent and child tables easier to manage.

Due to the breaking change, any existing hoardable users will have to:
* Re-run the install migration generator
* Add and seed `hoardable_id` to existing hoardable tables
* Add the trigger to hoardable tables

I hope for this to be the last schema change before preparing the first release candidate.

This PR also:
* Simplifies `version?` and `trashed?`
* Allows rollback of the install migration

closes #15 