### PR TITLE
fix / improve `has_one` relationship

### DIFF
--- a/lib/hoardable/error.rb
+++ b/lib/hoardable/error.rb
@@ -15,4 +15,16 @@ module Hoardable
       )
     end
   end
+
+  # An error to be raised when 'updated_at' columns are missing for {Hoardable::Model}s.
+  class UpdatedAtColumnMissingError < Error
+    def initialize(source_table_name)
+      super(
+        <<~LOG
+          '#{source_table_name}' does not have an 'updated_at' column, so Hoardable cannot look up
+          associated record versions with it. Add an 'updated_at' column to '#{source_table_name}'.
+        LOG
+      )
+    end
+  end
 end

--- a/lib/hoardable/version.rb
+++ b/lib/hoardable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hoardable
-  VERSION = '0.12.3'
+  VERSION = '0.12.4'
 end

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -554,6 +554,16 @@ class TestModel < Minitest::Test
     end
   end
 
+  it 'can access rich text record through version' do
+    post = PostWithRichText.create!(title: 'Title', content: '<div>Hello World</div>', user: user)
+    post.update!(content: '<div>Goodbye Cruel World</div>')
+    post.update!(title: 'New Title')
+    post.update!(content: '<div>Ahh, Welcome Back</div>')
+    assert_equal post.versions.first.content.body.to_plain_text, 'Hello World'
+    assert_equal post.versions.second.content.body.to_plain_text, 'Goodbye Cruel World'
+    assert_equal post.versions.third.content.body.to_plain_text, 'Goodbye Cruel World'
+  end
+
   if ActiveRecord.version >= ::Gem::Version.new('7.0')
     it 'creates encrypted rich text record for versions' do
       post = PostWithEncryptedRichText.create!(title: 'Title', content: '<div>Hello World</div>', user: user)


### PR DESCRIPTION
* fixes the association reflection lookup
* ensures all has one lookups happen temporally based on updated_at
* requires updated_at column on parent relationship
* adds test that has one lookups work on version records