### PR TITLE
fix untrashing record with serialized attributes

### DIFF
--- a/lib/hoardable/database_client.rb
+++ b/lib/hoardable/database_client.rb
@@ -55,7 +55,7 @@ module Hoardable
     end
 
     def source_attributes_without_primary_key
-      source_record.attributes_before_type_cast.without(source_primary_key, *generated_column_names).merge(
+      source_record.attributes.without(source_primary_key, *generated_column_names).merge(
         source_record.class.select(refreshable_column_names).find(source_record.id).slice(refreshable_column_names)
       )
     end

--- a/lib/hoardable/version.rb
+++ b/lib/hoardable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hoardable
-  VERSION = '0.12.9'
+  VERSION = '0.12.10'
 end

--- a/lib/hoardable/version_model.rb
+++ b/lib/hoardable/version_model.rb
@@ -130,7 +130,7 @@ module Hoardable
     end
 
     def hoardable_source_attributes
-      attributes_before_type_cast.without(
+      attributes.without(
         (self.class.column_names - self.class.superclass.column_names) +
         (SUPPORTS_VIRTUAL_COLUMNS ? self.class.columns.select(&:virtual?).map(&:name) : [])
       )

--- a/test/support/database.rb
+++ b/test/support/database.rb
@@ -65,6 +65,7 @@ ActiveRecord::Schema.define do
 
   create_table :users do |t|
     t.string :name, null: false
+    t.text :preferences, default: '{}'
     t.timestamps
   end
 

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -66,6 +66,7 @@ class User < ActiveRecord::Base
   has_many :posts
   has_one :profile, hoardable: true
   has_rich_text :bio, hoardable: true
+  serialize :preferences, JSON
 end
 
 class Profile < ActiveRecord::Base

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -66,6 +66,15 @@ class TestModel < Minitest::Test
     assert_instance_of Hoardable::PostVersion, post.versions.first
   end
 
+  it 'works with serialized attributes' do
+    user = User.create!(name: 'Joe Schmoe', preferences: { alerts: 'on' })
+    user.update!(preferences: { alerts: 'off' })
+    assert_equal user.versions.last.preferences, { 'alerts' => 'on' }
+    user.destroy!
+    user.versions.last.untrash!
+    assert_equal user.reload.preferences, { 'alerts' => 'off' }
+  end
+
   it 'can assign hoardable_id when primary key is different' do
     tag = Tag.create!(name: 'tug')
     tag.update!(name: 'tag')


### PR DESCRIPTION
when using `attributes_before_type_cast` to insert an unpersisted attribute into the versions table, it doesn't process the attribute with the ActiveRecord serialization logic. instead let's fully lean on ActiveRecord to process the attributes hash correctly when calling `.insert`.