### PR TITLE
spruce up README, remove `hoardable_note`, bump minor version

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,9 @@ end
 If a model-level option exists, it will use that. Otherwise, it will fall back to the global `Hoardable`
 config.
 
-### Relationships
+## Relationships
+
+### Belongs To Trashable
 
 Sometimes you’ll have a record that belongs to a parent record that you’ll trash. Now the child record’s
 foreign key will point to the non-existent trashed version of the parent. If you would like to have
@@ -321,10 +323,11 @@ class Comment
 end
 ```
 
-Sometimes you'll have a Hoardable record that `has_many` other Hoardable records and you will want
-to know the state of both the parent record and the children at a cetain point in time. You
-accomplish this by adding `hoardable: true` to the `has_many` relationship and using the
-`Hoardable.at` method:
+### Hoardable Has Many & Has One
+
+Sometimes you'll have a Hoardable record that `has_one` or `has_many` other Hoardable records and you will
+want to know the state of both the parent record and the children at a cetain point in time. You accomplish
+this by adding `hoardable: true` to the `has_many` relationship and using the `Hoardable.at` method:
 
 ```ruby
 class Post
@@ -363,6 +366,11 @@ a database trigger won’t allow you to.
 
 If you are ever unsure if a Hoardable record is a source record or a version, you can be sure by calling
 `version?` on it. If you want to get the true original source record ID, you can call `hoardable_id`.
+
+_Note:_ `Hoardable.at` is still very experimental and is potentially not very performant for querying large
+data sets.
+
+### Cascading Untrashing
 
 Sometimes you’ll trash something that `has_many :children, dependent: :destroy` and if you untrash the parent
 record, you’ll want to also untrash the children. Whenever a hoardable version is created in a database
@@ -417,9 +425,9 @@ Hoardable.at(datetime) do
 end
 ```
 
-### Known Gotchas
+## Known Gotchas
 
-#### Rails Fixtures
+### Rails Fixtures
 
 Rails uses a method called
 [`disable_referential_integrity`](https://github.com/rails/rails/blob/06e9fbd954ab113108a7982357553fdef285bff1/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb#L7)

--- a/README.md
+++ b/README.md
@@ -1,23 +1,21 @@
 # Hoardable ![gem version](https://img.shields.io/gem/v/hoardable?style=flat-square)
 
-Hoardable is an ActiveRecord extension for Ruby 2.6+, Rails 6.1+, and PostgreSQL that allows for
-versioning and soft-deletion of records through the use of _uni-temporal inherited tables_.
+Hoardable is an ActiveRecord extension for Ruby 2.6+, Rails 6.1+, and PostgreSQL that allows for versioning
+and soft-deletion of records through the use of _uni-temporal inherited tables_.
 
-[Temporal tables](https://en.wikipedia.org/wiki/Temporal_database) are a database design pattern
-where each row of a table contains data along with one or more time ranges. In the case of this gem,
-each database row has a time range that represents the row’s valid time range - hence
-"uni-temporal".
+[Temporal tables](https://en.wikipedia.org/wiki/Temporal_database) are a database design pattern where each
+row of a table contains data along with one or more time ranges. In the case of this gem, each database row
+has a time range that represents the row’s valid time range - hence "uni-temporal".
 
-[Table inheritance](https://www.postgresql.org/docs/14/ddl-inherit.html) is a feature of PostgreSQL
-that allows a table to inherit all columns of a parent table. The descendant table’s schema will
-stay in sync with its parent. If a new column is added to or removed from the parent, the schema
-change is reflected on its descendants.
+[Table inheritance](https://www.postgresql.org/docs/14/ddl-inherit.html) is a feature of PostgreSQL that
+allows a table to inherit all columns of a parent table. The descendant table’s schema will stay in sync with
+its parent. If a new column is added to or removed from the parent, the schema change is reflected on its
+descendants.
 
-With these concepts combined, `hoardable` offers a simple and effective model versioning system for
-Rails. Versions of records are stored in separate, inherited tables along with their valid time
-ranges and contextual data. Compared to other Rails-oriented versioning systems, this gem strives to
-be more explicit and obvious on the lower RDBS level while still familiar and convenient to use
-within Ruby on Rails.
+With these concepts combined, `hoardable` offers a simple and effective model versioning system for Rails.
+Versions of records are stored in separate, inherited tables along with their valid time ranges and
+contextual data. Compared to other Rails-oriented versioning systems, this gem strives to be more explicit
+and obvious on the lower database level, while still familiar and convenient to use within Ruby on Rails.
 
 [👉 Documentation](https://www.rubydoc.info/gems/hoardable)
 
@@ -36,19 +34,16 @@ bin/rails g hoardable:install
 bin/rails db:migrate
 ```
 
-This will generate PostgreSQL functions, an initiailzer, and set `config.active_record.schema_format
-= :sql` in `application.rb`.
+This will generate PostgreSQL functions, an initiailzer, and set `config.active_record.schema_format = :sql`
+in `application.rb`.
 
 ### Model Installation
 
-You must include `Hoardable::Model` into an ActiveRecord model that you would like to hoard versions
-of:
+You must include `Hoardable::Model` into an ActiveRecord model that you would like to hoard versions of:
 
 ```ruby
 class Post < ActiveRecord::Base
   include Hoardable::Model
-  belongs_to :user
-  has_many :comments, dependent: :destroy
   ...
 end
 ```
@@ -60,34 +55,31 @@ bin/rails g hoardable:migration Post
 bin/rails db:migrate
 ```
 
-By default, it will try to guess the foreign key type for the `_versions` table based on the primary
-key of the model specified in the migration generator above. If you want/need to specify this
-explicitly, you can do so:
+By default, it will guess the foreign key type for the `_versions` table based on the primary key of the
+model specified in the migration generator above. If you want/need to specify this explicitly, you can do so:
 
 ```
 bin/rails g hoardable:migration Post --foreign-key-type uuid
 ```
 
-_Note:_ Creating an inherited table does not copy over the indexes from the parent table. If you
-need to query versions often, you should add appropriate indexes to the `_versions` tables.
+_Note:_ Creating an inherited table does not inherit the indexes from the parent table. If you need to query
+versions often, you should add appropriate indexes to the `_versions` tables.
 
 ## Usage
 
 ### Overview
 
-Once you include `Hoardable::Model` into a model, it will dynamically generate a "Version" subclass
-of that model. As we continue our example from above:
+Once you include `Hoardable::Model` into a model, it will dynamically generate a "Version" subclass of that
+model. As we continue our example from above:
 
-```
-$ irb
->> Post
-=> Post(id: integer, body: text, user_id: integer, created_at: datetime, hoardable_id: integer)
->> PostVersion
-=> PostVersion(id: integer, body: text, user_id: integer, created_at: datetime, hoardable_id: integer, _data: jsonb, _during: tsrange)
+```ruby
+Post #=> Post(id: integer, created_at: datetime, updated_at: datetime, hoardable_id: integer)
+PostVersion #=> PostVersion(id: integer, created_at: datetime, updated_at: datetime, hoardable_id: integer, _data: jsonb, _during: tsrange, _event_uuid: uuid, _operation: enum)
+Post.version_class #=> same as `PostVersion`
 ```
 
-A `Post` now `has_many :versions`. With the default configuration, whenever an update and deletion
-of a `Post` occurs, a version is created:
+A `Post` now `has_many :versions`. With the default configuration, whenever an update and deletion of a
+`Post` occurs, a version is created:
 
 ```ruby
 post = Post.create!(title: "Title")
@@ -102,7 +94,11 @@ Post.find(post.id) # raises ActiveRecord::RecordNotFound
 ```
 
 Each `PostVersion` has access to the same attributes, relationships, and other model behavior that
-`Post` has, but as a read-only record.
+`Post` has, but as a read-only record:
+
+``` ruby
+post.versions.last.update!(title: "Rewrite history") #=> raises ActiveRecord::ReadOnlyRecord
+```
 
 If you ever need to revert to a specific version, you can call `version.revert!` on it.
 
@@ -113,8 +109,8 @@ post.reload.versions.last.revert!
 post.title # => "Title"
 ```
 
-If you would like to untrash a specific version, you can call `version.untrash!` on it. This will
-re-insert the model in the parent class’s table with the original primary key.
+If you would like to untrash a specific version of a record you deleted, you can call `version.untrash!` on
+it. This will re-insert the model in the parent class’s table with the original primary key.
 
 ```ruby
 post = Post.create!(title: "Title")
@@ -128,12 +124,17 @@ trashed_post.untrash!
 Post.find(post.id) # #<Post>
 ```
 
+_Note:_ You will notice above that both `posts` and `post_versions` pull from the same ID sequence. This
+allows for uniquely identifying source records and versions when results are mixed together. Both a source
+record and versions have an automatically managed `hoardable_id` that always represents the primary key value
+of the original source record.
+
 ### Querying and Temporal Lookup
 
 Since a `PostVersion` is an `ActiveRecord` class, you can query them like another model resource:
 
 ```ruby
-post.versions.where(user_id: Current.user.id, body: "Cool!")
+post.versions.where(state: :draft)
 ```
 
 If you want to look-up the version of a record at a specific time, you can use the `.at` method:
@@ -141,7 +142,8 @@ If you want to look-up the version of a record at a specific time, you can use t
 ```ruby
 post.at(1.day.ago) # => #<PostVersion>
 # or you can use the scope on the version model class
-PostVersion.at(1.day.ago).find_by(hoardable_id: post.id) # => #<PostVersion>
+post.versions.at(1.day.ago) # => #<PostVersion>
+PostVersion.at(1.day.ago).find_by(hoardable_id: post.id) # => same as above
 ```
 
 The source model class also has an `.at` method:
@@ -150,35 +152,32 @@ The source model class also has an `.at` method:
 Post.at(1.day.ago) # => [#<Post>, #<Post>]
 ```
 
-This will return an ActiveRecord scoped query of all `Post` and `PostVersion` records that were
-valid at that time, all cast as instances of `Post`.
+This will return an ActiveRecord scoped query of all `Post` and `PostVersion` records that were valid at that
+time, all cast as instances of `Post`.
 
-There is also an `at` method on `Hoardable` itself for more complex temporal resource querying. See
-[Relationships](#relationships) for more.
+There is also an `at` method on `Hoardable` itself for more complex and experimental temporal resource
+querying. See [Relationships](#relationships) for more.
 
-By default, `hoardable` will keep copies of records you have destroyed. You can query them
-specifically with:
+By default, `hoardable` will keep copies of records you have destroyed. You can query them specifically with:
 
 ```ruby
 PostVersion.trashed
-Post.version_class.trashed # <- same thing as above
+Post.version_class.trashed # <- same as above
 ```
 
-_Note:_ A `Version` is not created upon initial parent model creation. To accurately track the
-beginning of the first temporal period, you will need to ensure the source model table has a
-`created_at` timestamp column. If this is missing, an error will be raised.
+_Note:_ A `Version` is not created upon initial parent model creation. To accurately track the beginning of
+the first temporal period, you will need to ensure the source model table has a `created_at` timestamp
+column. If this is missing, an error will be raised.
 
 ### Tracking Contextual Data
 
-You’ll often want to track contextual data about the creation of a version. There are 3 optional
-symbol keys that are provided for tracking contextual information:
+You’ll often want to track contextual data about the creation of a version. There are 2 options that can be
+provided for tracking contextual information:
 
 - `:whodunit` - an identifier for who is responsible for creating the version
-- `:note` - a description regarding the versioning
 - `:meta` - any other contextual information you’d like to store along with the version
 
-This information is stored in a `jsonb` column. Each key’s value can be in the format of your
-choosing.
+This information is stored in a `jsonb` column. Each key’s value can be in the format of your choosing.
 
 One convenient way to assign contextual data to these is by defining a proc in an initializer, i.e.:
 
@@ -192,17 +191,17 @@ post.update!(status: 'live')
 post.reload.versions.last.hoardable_whodunit # => 123
 ```
 
-You can also set this context manually as well, just remember to clear them afterwards.
+You can also set this context manually as well:
 
 ```ruby
-Hoardable.note = "reverting due to accidental deletion"
+Hoardable.meta = { note: "reverting due to accidental deletion" }
 post.update!(title: "We’re back!")
-Hoardable.note = nil
-post.reload.versions.last.hoardable_note # => "reverting due to accidental deletion"
+Hoardable.meta = nil
+post.reload.versions.last.hoardable_meta['note'] # => "reverting due to accidental deletion"
 ```
 
-A more useful pattern is to use `Hoardable.with` to set the context around a block. A good example
-of this would be in `ApplicationController`:
+A more useful pattern however is to use `Hoardable.with` to set the context around a block. For example, you
+could have the following in your `ApplicationController`:
 
 ```ruby
 class ApplicationController < ActionController::Base
@@ -220,9 +219,9 @@ end
 ```
 
 `hoardable` will also automatically capture the ActiveRecord
-[changes](https://api.rubyonrails.org/classes/ActiveModel/Dirty.html#method-i-changes) hash, the
-`operation` that cause the version (`update` or `delete`), and it will also tag all versions created
-in the same database transaction with a shared and unique `event_uuid`. These are available as:
+[changes](https://api.rubyonrails.org/classes/ActiveModel/Dirty.html#method-i-changes) hash, the `operation`
+that cause the version (`update` or `delete`), and it will also tag all versions created in the same database
+transaction with a shared and unique `event_uuid` for that transaction. These are available as:
 
 ```ruby
 version.changes
@@ -232,12 +231,12 @@ version.hoardable_event_uuid
 
 ### Model Callbacks
 
-Sometimes you might want to do something with a version after it gets inserted to the database. You
-can access it in `after_versioned` callbacks on the source record as `hoardable_version`. These
-happen within `ActiveRecord`’s `.save`, which is enclosed in an ActiveRecord transaction.
+Sometimes you might want to do something with a version after it gets inserted to the database. You can
+access it in `after_versioned` callbacks on the source record as `hoardable_version`. These happen within
+`ActiveRecord`’s `.save`, which is enclosed in an ActiveRecord transaction.
 
-There are also `after_reverted` and `after_untrashed` callbacks available as well, which are called
-on the source record after a version is reverted or untrashed.
+There are also `after_reverted` and `after_untrashed` callbacks available as well, which are called on the
+source record after a version is reverted or untrashed.
 
 ```ruby
 class User
@@ -272,11 +271,11 @@ Hoardable.version_updates # => default true
 Hoardable.save_trash # => default true
 ```
 
-`Hoardable.enabled` controls whether versions will be ever be created.
+`Hoardable.enabled` globally controls whether versions will be ever be created.
 
-`Hoardable.version_updates` controls whether versions get created on record updates.
+`Hoardable.version_updates` globally controls whether versions get created on record updates.
 
-`Hoardable.save_trash` controls whether to create versions upon record deletion. When this is set to
+`Hoardable.save_trash` globally controls whether to create versions upon record deletion. When this is set to
 `false`, all versions of a record will be deleted when the record is destroyed.
 
 If you would like to temporarily set a config setting, you can use `Hoardable.with`:
@@ -287,7 +286,7 @@ Hoardable.with(enabled: false) do
 end
 ```
 
-You can also configure these variables per `ActiveRecord` class as well using `hoardable_config`:
+You can also configure these settings per `ActiveRecord` class using `hoardable_config`:
 
 ```ruby
 class Comment < ActiveRecord::Base
@@ -305,18 +304,15 @@ Comment.with_hoardable_config(version_updates: true) do
 end
 ```
 
-If a model-level option exists, it will use that. Otherwise, it will fall back to the global
-`Hoardable` config.
+If a model-level option exists, it will use that. Otherwise, it will fall back to the global `Hoardable`
+config.
 
 ### Relationships
 
-As in life, sometimes relationships can be hard, but here are some pointers on handling associations
-with `Hoardable` considerations.
-
-Sometimes you’ll have a record that belongs to a parent record that you’ll trash. Now the child
-record’s foreign key will point to the non-existent trashed version of the parent. If you would like
-to have `belongs_to` resolve to the trashed parent model in this case, you can give it the option of
-`trashable: true`:
+Sometimes you’ll have a record that belongs to a parent record that you’ll trash. Now the child record’s
+foreign key will point to the non-existent trashed version of the parent. If you would like to have
+`belongs_to` resolve to the trashed parent model in this case, you can give it the option of `trashable:
+true`:
 
 ```ruby
 class Comment
@@ -358,22 +354,21 @@ Hoardable.at(datetime) do
 end
 ```
 
-There are some additional details to point out above. Firstly, it is important to note that the
-final `post.id` yields a different value than the originally created `Post`. This is because the
-`post` within the `#at` block is actually a temporal version, since it has been subsequently
-updated, but it has been reified as a `Post` for the purposes of your business logic (serialization,
-rendering views, exporting, etc). Don’t fret - you will not be able to commit any updates to the
-version, even though it is masquerading as a `Post`.
+There are some additional details to point out above. Firstly, it is important to note that the final
+`post.id` yields a different value than the originally created `Post`. This is because the `post` within the
+`#at` block is actually a temporal version, since it has been subsequently updated, but is reified as a
+`Post` for the purposes of your business logic (serialization, rendering views, exporting, etc). Don’t fret -
+you will not be able to commit any updates to the version, even though it is masquerading as a `Post` because
+a database trigger won’t allow you to.
 
-If you are ever unsure if a Hoardable record is a "source" or a "version", you can be sure by
-calling `version?` on it. If you want to get the true original source record ID, you can call
-`hoardable_id`. 
+If you are ever unsure if a Hoardable record is a source record or a version, you can be sure by calling
+`version?` on it. If you want to get the true original source record ID, you can call `hoardable_id`.
 
-Sometimes you’ll trash something that `has_many :children, dependent: :destroy` and want
-to untrash everything in a similar dependent manner. Whenever a hoardable version is created in a
-database transaction, it will create or re-use a unique event UUID for that transaction and tag all
-versions created with it. That way, when you `untrash!` a record, you can find and `untrash!`
-records that were trashed with it:
+Sometimes you’ll trash something that `has_many :children, dependent: :destroy` and if you untrash the parent
+record, you’ll want to also untrash the children. Whenever a hoardable version is created in a database
+transaction, it will create or re-use a unique event UUID for the current database transaction and tag all
+versions created with it. That way, when you `untrash!` a record, you could find and `untrash!` records that
+were trashed with it:
 
 ```ruby
 class Post < ActiveRecord::Base
@@ -392,18 +387,17 @@ end
 
 ### Action Text
 
-Hoardable provides support for ActiveRecord models with `has_rich_text`. First, you must create a
-temporal table for `ActionText::RichText`:
+Hoardable provides support for ActiveRecord models with `has_rich_text`. First, you must create a temporal
+table for `ActionText::RichText`:
 
 ```
 bin/rails g hoardable:migration ActionText::RichText
 bin/rails db:migrate
 ```
 
-Then in your model, include `Hoardable::Model` and provide the `hoardable: true` keyword to
-`has_rich_text`:
+Then in your model include `Hoardable::Model` and provide the `hoardable: true` keyword to `has_rich_text`:
 
-``` ruby
+```ruby
 class Post < ActiveRecord::Base
   include Hoardable::Model # or `Hoardable::Associations` if you don't need `PostVersion`
   has_rich_text :content, hoardable: true
@@ -412,7 +406,7 @@ end
 
 Now the `rich_text_content` relationship will be managed as a Hoardable `has_one` relationship:
 
-``` ruby
+```ruby
 post = Post.create!(content: '<div>Hello World</div>')
 datetime = DateTime.current
 post.update!(content: '<div>Goodbye Cruel World</div>')
@@ -429,58 +423,55 @@ end
 
 Rails uses a method called
 [`disable_referential_integrity`](https://github.com/rails/rails/blob/06e9fbd954ab113108a7982357553fdef285bff1/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb#L7)
-when inserting fixtures into the database. This disables PostgreSQL triggers, which Hoardable relies
-on for assigning `hoardable_id` from the primary key’s value. If you would still like to use
-fixtures, you must specify the primary key’s value and `hoardable_id` to the same identifier value
-in the fixture. This is not an issue with fixture replacement libraries like `factory_girl` or
+when inserting fixtures into the database. This disables PostgreSQL triggers, which Hoardable relies on for
+assigning `hoardable_id` from the primary key’s value. If you would still like to use fixtures, you must
+specify the primary key’s value and `hoardable_id` to the same identifier value in the fixture. This is not
+an issue with fixture replacement libraries like `factory_bot` or
 [`world_factory`](https://github.com/FutureProofRetail/world_factory) however.
 
 ## Gem Comparison
 
 #### [`paper_trail`](https://github.com/paper-trail-gem/paper_trail)
 
-`paper_trail` is maybe the most popular and fully featured gem in this space. It works for other
-database types than PostgeSQL and (by default) stores all versions of all versioned models in a
-single `versions` table. It stores changes in a `text`, `json`, or `jsonb` column. In order to
-efficiently query the `versions` table, a `jsonb` column should be used, which takes up a lot of
-space to index. Unless you customize your configuration, all `versions` for all models types are
-in the same table which is inefficient if you are only interested in querying versions of a single
-model. By contrast, `hoardable` stores versions in smaller, isolated and inherited tables with the
-same database columns as their parents, which are more efficient for querying as well as auditing
-for truncating and dropping. The concept of a `temporal` time-frame does not exist for a single
-version since there is only a `created_at` timestamp.
+`paper_trail` is maybe the most popular and fully featured gem in this space. It works for other database
+types than PostgeSQL and (by default) stores all versions of all versioned models in a single `versions`
+table. It stores changes in a `text`, `json`, or `jsonb` column. In order to efficiently query the `versions`
+table, a `jsonb` column should be used, which takes up a lot of space to index. Unless you customize your
+configuration, all `versions` for all models types are in the same table which is inefficient if you are only
+interested in querying versions of a single model. By contrast, `hoardable` stores versions in smaller,
+isolated and inherited tables with the same database columns as their parents, which are more efficient for
+querying as well as auditing for truncating and dropping. The concept of a `temporal` time-frame does not
+exist for a single version since there is only a `created_at` timestamp.
 
 #### [`audited`](https://github.com/collectiveidea/audited)
 
-`audited` works in a similar manner as `paper_trail`. It stores all versions for all model types in
-a single table, you must opt into using `jsonb` as the column type to store "changes", in case you
-want to query them, and there is no concept of a `temporal` time-frame for a single version. It
-makes opinionated decisions about contextual data requirements and stores them as top level data
-types on the `audited` table.
+`audited` works in a similar manner as `paper_trail`. It stores all versions for all model types in a single
+table, you must opt into using `jsonb` as the column type to store "changes", in case you want to query them,
+and there is no concept of a `temporal` time-frame for a single version. It makes opinionated decisions about
+contextual data requirements and stores them as top level data types on the `audited` table.
 
 #### [`discard`](https://github.com/jhawthorn/discard)
 
-`discard` only covers soft-deletion. The act of "soft deleting" a record is only captured through
-the time-stamping of a `discarded_at` column on the records table; there is no other capturing of
-the event that caused the soft deletion unless you implement it yourself. Once the "discarded"
-record is restored, the previous "discarded" awareness is lost. Since "discarded" records exist in
-the same table as "undiscarded" records, you must explicitly omit the discarded records from queries
-across your app to keep them from leaking in.
+`discard` only covers soft-deletion. The act of "soft deleting" a record is only captured through the
+time-stamping of a `discarded_at` column on the records table; there is no other capturing of the event that
+caused the soft deletion unless you implement it yourself. Once the "discarded" record is restored, the
+previous "discarded" awareness is lost. Since "discarded" records exist in the same table as "undiscarded"
+records, you must explicitly omit the discarded records from queries across your app to keep them from
+leaking in.
 
 #### [`paranoia`](https://github.com/rubysherpas/paranoia)
 
-`paranoia` also only covers soft-deletion. In their README, they recommend using `discard` instead
-of `paranoia` because of the fact they override ActiveRecord’s `delete` and `destroy` methods.
-`hoardable` employs callbacks to create trashed versions instead of overriding methods. Otherwise,
-`paranoia` works similarly to `discard` in that it keeps deleted records in the same table and tags
-them with a `deleted_at` timestamp. No other information about the soft-deletion event is stored.
+`paranoia` also only covers soft-deletion. In their README, they recommend using `discard` instead of
+`paranoia` because of the fact they override ActiveRecord’s `delete` and `destroy` methods. `hoardable`
+employs callbacks to create trashed versions instead of overriding methods. Otherwise, `paranoia` works
+similarly to `discard` in that it keeps deleted records in the same table and tags them with a `deleted_at`
+timestamp. No other information about the soft-deletion event is stored.
 
 #### [`logidze`](https://github.com/palkan/logidze)
 
-`logidze` is an interesting versioning alternative that leverages the power of PostgreSQL triggers.
-Instead of storing the previous versions or changes in a separate table, it stores them in a
-proprietary JSON format directly on the database row of the record itself. If does not support soft
-deletion.
+`logidze` is an interesting versioning alternative that leverages the power of PostgreSQL triggers. Instead
+of storing the previous versions or changes in a separate table, it stores them in a proprietary JSON format
+directly on the database row of the record itself. If does not support soft deletion.
 
 ## Contributing
 

--- a/lib/hoardable/engine.rb
+++ b/lib/hoardable/engine.rb
@@ -4,7 +4,7 @@
 module Hoardable
   # Symbols for use with setting contextual data, when creating versions. See
   # {file:README.md#tracking-contextual-data README} for more.
-  DATA_KEYS = %i[meta whodunit note event_uuid].freeze
+  DATA_KEYS = %i[meta whodunit event_uuid].freeze
 
   # Symbols for use with setting {Hoardable} configuration. See {file:README.md#configuration
   # README} for more.

--- a/lib/hoardable/scopes.rb
+++ b/lib/hoardable/scopes.rb
@@ -73,7 +73,7 @@ module Hoardable
     private
 
     def tableoid
-      connection.execute("SELECT oid FROM pg_class WHERE relname = '#{table_name}'")[0]['oid']
+      @tableoid ||= connection.execute("SELECT oid FROM pg_class WHERE relname = '#{table_name}'")[0]['oid']
     end
   end
 end

--- a/lib/hoardable/version.rb
+++ b/lib/hoardable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hoardable
-  VERSION = '0.12.10'
+  VERSION = '0.13.0'
 end

--- a/sig/hoardable.rbs
+++ b/sig/hoardable.rbs
@@ -1,6 +1,6 @@
 module Hoardable
   VERSION: String
-  DATA_KEYS: [:meta, :whodunit, :note, :event_uuid]
+  DATA_KEYS: [:meta, :whodunit, :event_uuid]
   CONFIG_KEYS: [:enabled, :version_updates, :save_trash]
   VERSION_CLASS_SUFFIX: String
   VERSION_TABLE_SUFFIX: String
@@ -57,7 +57,7 @@ module Hoardable
     def source_attributes_without_primary_key: -> untyped
     def initialize_temporal_range: -> Range
     def initialize_hoardable_data: -> untyped
-    def assign_hoardable_context: (:event_uuid | :meta | :note | :whodunit key) -> nil
+    def assign_hoardable_context: (:event_uuid | :meta | :whodunit key) -> nil
     def unset_hoardable_version_and_event_uuid: -> nil
     def previous_temporal_tsrange_end: -> untyped
     def hoardable_source_epoch: -> untyped

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,8 +32,8 @@ end
 
 Rails.initialize!
 
-SUPPORTS_ENCRYPTED_ACTION_TEXT = ActiveRecord.version >= ::Gem::Version.new('7.0.4')
-SUPPORTS_VIRTUAL_COLUMNS = ActiveRecord.version >= ::Gem::Version.new('7.0.0')
+SUPPORTS_ENCRYPTED_ACTION_TEXT = ActiveRecord.version >= Gem::Version.new('7.0.4')
+SUPPORTS_VIRTUAL_COLUMNS = ActiveRecord.version >= Gem::Version.new('7.0.0')
 
 require_relative 'support/models'
 require_relative 'support/database'

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -292,13 +292,11 @@ class TestModel < Minitest::Test
     Current.user = nil
   end
 
-  it 'tracks note and meta' do
-    note = 'Oopsie'
+  it 'tracks meta' do
     meta = { 'foo' => 'bar' }
-    Hoardable.with(note: note, meta: meta) do
+    Hoardable.with(meta: meta) do
       update_post
       version = post.versions.first
-      assert_equal version.hoardable_note, note
       assert_equal version.hoardable_meta, meta
     end
   end


### PR DESCRIPTION
Since leaving a note could be considered part of the `meta` of a version, let's remove the global data handling for it and assume it will be handled via `meta`.