### PR TITLE
fix eager-loading issue related to ActionText::EncryptedRichText

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.14.2
+
+- Fixes an eager loading issue regarding `ActionText::EncryptedRichText`
+
 ## 0.14.0
 
 - *Breaking Change* - Support for Ruby 2.6 is dropped

--- a/lib/hoardable/encrypted_rich_text.rb
+++ b/lib/hoardable/encrypted_rich_text.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 module Hoardable
-  # A {Hoardable} subclass of {ActionText::EncryptedRichText}.
-  class EncryptedRichText < ActionText::EncryptedRichText
+  # A {Hoardable} subclass of {ActionText::RichText} like {ActionText::EncryptedRichText}.
+  class EncryptedRichText < ActionText::RichText
     include Model
+    encrypts :body
   end
 end

--- a/lib/hoardable/engine.rb
+++ b/lib/hoardable/engine.rb
@@ -105,7 +105,7 @@ module Hoardable
     initializer 'hoardable.action_text' do
       ActiveSupport.on_load(:action_text_rich_text) do
         require_relative 'rich_text'
-        # require_relative 'encrypted_rich_text' if SUPPORTS_ENCRYPTED_ACTION_TEXT
+        require_relative 'encrypted_rich_text' if SUPPORTS_ENCRYPTED_ACTION_TEXT
       end
     end
   end

--- a/lib/hoardable/engine.rb
+++ b/lib/hoardable/engine.rb
@@ -105,7 +105,7 @@ module Hoardable
     initializer 'hoardable.action_text' do
       ActiveSupport.on_load(:action_text_rich_text) do
         require_relative 'rich_text'
-        require_relative 'encrypted_rich_text' if SUPPORTS_ENCRYPTED_ACTION_TEXT
+        # require_relative 'encrypted_rich_text' if SUPPORTS_ENCRYPTED_ACTION_TEXT
       end
     end
   end

--- a/lib/hoardable/has_rich_text.rb
+++ b/lib/hoardable/has_rich_text.rb
@@ -14,7 +14,6 @@ module Hoardable
         end
         return unless hoardable
 
-        'ActionText::RichText'.constantize # forces ActionText::RichText to load if it has not
         reflection_options = reflections["rich_text_#{name}"].options
         reflection_options[:class_name] = reflection_options[:class_name].sub(/ActionText/, 'Hoardable')
       end

--- a/lib/hoardable/version.rb
+++ b/lib/hoardable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hoardable
-  VERSION = '0.14.1'
+  VERSION = '0.14.2'
 end


### PR DESCRIPTION
if `config.eager_load` is true, when hoardable's [rails engine's initializer runs for `action_text_rich_text`](https://github.com/waymondo/hoardable/blob/c0fe3a9d517041ba674d712a64f6c7ee3e306eb0/lib/hoardable/engine.rb#L105-L110), it's possible for `ActionText::EncryptedRichText` to not be loaded yet.

since [the actual implementation of `ActionText::EncryptedRichText` is so lightweight](https://github.com/rails/rails/blob/e55ccf0f1090b11e13b54b35a215e23c6695d094/actiontext/app/models/action_text/encrypted_rich_text.rb), lets just copy the pattern in our own version as a subclass of `ActionText::RichText`.

connect to https://github.com/rails/rails/pull/47737