### PR TITLE
make the versions table primary key column the actual primary key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.14.3
+
+- The migration template is updated to make the primary key on the versions table its actual primary key.
+
 ## 0.14.2
 
 - Fixes an eager loading issue regarding `ActionText::EncryptedRichText`

--- a/lib/generators/hoardable/templates/migration.rb.erb
+++ b/lib/generators/hoardable/templates/migration.rb.erb
@@ -17,6 +17,7 @@ class Create<%= class_name.singularize.delete(':') %>Versions < ActiveRecord::Mi
     reversible do |dir|
       dir.up do
         execute('ALTER TABLE <%= singularized_table_name %>_versions ADD PRIMARY KEY (<%= primary_key %>);')
+        # remove the following line if you plan on seeding +hoardable_id+ outside the migration
         execute('UPDATE <%= table_name %> SET hoardable_id = <%= primary_key %>;')
       end
     end

--- a/lib/generators/hoardable/templates/migration.rb.erb
+++ b/lib/generators/hoardable/templates/migration.rb.erb
@@ -6,8 +6,8 @@ class Create<%= class_name.singularize.delete(':') %>Versions < ActiveRecord::Mi
     add_index :<%= table_name %>, :hoardable_id
     create_table(
       :<%= singularized_table_name %>_versions,
-      primary_key: {<%= primary_key %>: :<%= foreign_key_type %>},
-      options: 'INHERITS (<%= table_name %>)'
+      id: false, 
+      options: 'INHERITS (<%= table_name %>)',
     ) do |t|
       t.jsonb :_data
       t.tsrange :_during, null: false
@@ -16,6 +16,7 @@ class Create<%= class_name.singularize.delete(':') %>Versions < ActiveRecord::Mi
     end
     reversible do |dir|
       dir.up do
+        execute('ALTER TABLE <%= singularized_table_name %>_versions ADD PRIMARY KEY (<%= primary_key %>);')
         execute('UPDATE <%= table_name %> SET hoardable_id = <%= primary_key %>;')
       end
     end

--- a/lib/generators/hoardable/templates/migration.rb.erb
+++ b/lib/generators/hoardable/templates/migration.rb.erb
@@ -4,7 +4,11 @@ class Create<%= class_name.singularize.delete(':') %>Versions < ActiveRecord::Mi
   def change
     add_column :<%= table_name %>, :hoardable_id, :<%= foreign_key_type %>
     add_index :<%= table_name %>, :hoardable_id
-    create_table :<%= singularized_table_name %>_versions, id: false, options: 'INHERITS (<%= table_name %>)' do |t|
+    create_table(
+      :<%= singularized_table_name %>_versions,
+      primary_key: {<%= primary_key %>: :<%= foreign_key_type %>},
+      options: 'INHERITS (<%= table_name %>)'
+    ) do |t|
       t.jsonb :_data
       t.tsrange :_during, null: false
       t.uuid :_event_uuid, null: false, index: true

--- a/lib/hoardable/version.rb
+++ b/lib/hoardable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hoardable
-  VERSION = '0.14.2'
+  VERSION = '0.14.3'
 end

--- a/test/test_migration_generator.rb
+++ b/test/test_migration_generator.rb
@@ -10,7 +10,7 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
 
   def shared_post_assertions
     assert_migration 'db/migrate/create_post_versions.rb' do |migration|
-      assert_match(/create_table :post_versions/, migration)
+      assert_match(/create_table\(\n(\s)*:post_versions/, migration)
       assert_match(/:hoardable_id, :bigint/, migration)
       assert_match(/create_trigger :posts_set_hoardable_id, on: :posts/, migration)
     end
@@ -18,7 +18,7 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
 
   def shared_book_assertions(foreign_key_type = 'uuid')
     assert_migration 'db/migrate/create_book_versions.rb' do |migration|
-      assert_match(/create_table :book_versions/, migration)
+      assert_match(/create_table\(\n(\s)*:book_versions/, migration)
       assert_match(":hoardable_id, :#{foreign_key_type}", migration)
     end
   end
@@ -56,15 +56,8 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
   it 'generates migration with namespaced model name' do
     run_generator ['ActionText::RichText']
     assert_migration 'db/migrate/create_action_text_rich_text_versions.rb' do |migration|
-      assert_match(/create_table :action_text_rich_text_versions/, migration)
+      assert_match(/create_table\(\n(\s)*:action_text_rich_text_versions/, migration)
       assert_match(':hoardable_id, :bigint', migration)
-    end
-  end
-
-  it 'generates unique index that matches primary key' do
-    run_generator ['Tag']
-    assert_migration 'db/migrate/create_tag_versions.rb' do |migration|
-      assert_match(':tag_versions, :primary_id, unique: true', migration)
     end
   end
 


### PR DESCRIPTION
according to the [Postgres docs](https://www.postgresql.org/docs/current/ddl-inherit.html):
```
Other types of constraints (unique, primary key, and foreign key constraints) are not inherited
```

this means that the `_versions` table id columns that inherit the parent table's sequence weren't actually considered the primary key column.

this change drops the unique index on the inherited table's primary key column and alters the descendant table to make it the primary column for the table instead.