### PR TITLE
replace `tableoid` where clause with `FROM ONLY`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,12 +28,12 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 3.0
-          - 3.1
-          - 3.2
+          - "3.0"
+          - "3.1"
+          - "3.2"
         rails: 
-          - 7.0
-          # - 7.1
+          - "7.0"
+          # - "7.1"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,10 +28,10 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - 3.0
+          - 3.1
           - 3.2
-          - 2.7
         rails: 
-          - 6.1
           - 7.0
           # - 7.1
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14
+        image: postgres:16
         env:
           POSTGRES_DB: hoardable
           POSTGRES_PASSWORD: password
@@ -25,18 +25,22 @@ jobs:
         ports:
           - 5432:5432
 
-    strategy:
+    strategy:    
       matrix:
         ruby:
           - 3.2
-          - 3.1
-          - 3.0
           - 2.7
+        rails: 
+          - 6.1
+          - 7.0
+          # - 7.1
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
+        env: 
+          RAILS_VERSION: ${{ matrix.rails }}
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
         ports:
           - 5432:5432
 
-    strategy:    
+    strategy:
       matrix:
         ruby:
           - 3.2
@@ -47,6 +47,7 @@ jobs:
       - name: Run the default task
         env:
           RAILS_ENV: test
+          RAILS_VERSION: ${{ matrix.rails }}
           POSTGRES_USER: postgres
           PGPASSWORD: password
           POSTGRES_PASSWORD: password

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.15.0
+
+- *Breaking Change* - Support for Ruby 2.7 and Rails 6.1 is dropped
+- *Breaking Change* - The default scoping clause that controls the inherited table SQL construction
+  changes from a where clause using `tableoid`s to using `FROM ONLY`.
+
 ## 0.14.3
 
 - The migration template is updated to make the primary key on the versions table its actual primary key.

--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,6 @@
 
 source 'https://rubygems.org'
 
-puts "#############"
-pp ENV["RAILS_VERSION"]
-puts "#############"
-
 gem 'debug'
 if (rails_version = ENV['RAILS_VERSION'])
   gem 'rails', "~> #{rails_version}.0"

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,10 @@
 
 source 'https://rubygems.org'
 
+puts "#############"
+pp ENV["RAILS_VERSION"]
+puts "#############"
+
 gem 'debug'
 if (rails_version = ENV['RAILS_VERSION'])
   gem 'rails', "~> #{rails_version}.0"

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,10 @@
 source 'https://rubygems.org'
 
 gem 'debug'
-gem 'minitest'
-gem 'rails', "~> #{ENV.fetch("RAILS_VERSION", "7.1")}"
-gem 'rake'
+if ENV['RAILS_VERSION']
+  gem 'rails', "~> #{ENV.fetch("RAILS_VERSION")}"
+else
+  gem 'rails'
+end
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@
 
 source 'https://rubygems.org'
 
-gem 'benchmark-ips'
 gem 'debug'
 gem 'minitest'
 gem 'rails', "~> #{ENV.fetch("RAILS_VERSION", "7.1")}"

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,8 @@
 source 'https://rubygems.org'
 
 gem 'debug'
-if ENV['RAILS_VERSION']
-  gem 'rails', "~> #{ENV.fetch("RAILS_VERSION")}"
+if (rails_version = ENV['RAILS_VERSION'])
+  gem 'rails', "~> #{rails_version}.0"
 else
   gem 'rails'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -2,14 +2,10 @@
 
 source 'https://rubygems.org'
 
-gem 'benchmark-ips', '~> 2.10'
-gem 'debug', '~> 1.6'
-gem 'minitest', '~> 5.0'
-gem 'rails', '>= 6.1'
-gem 'rake', '~> 13.0'
-gem 'rubocop', '~> 1.21'
-gem 'rubocop-minitest', '~> 0.20'
-gem 'rubocop-rake', '~> 0.6'
-gem 'yard', '~> 0.9'
+gem 'benchmark-ips'
+gem 'debug'
+gem 'minitest'
+gem 'rails', "~> #{ENV.fetch("RAILS_VERSION", "7.1")}"
+gem 'rake'
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ where each row of a table contains data along with one or more time ranges. In t
 each database row has a time range that represents the row’s valid time range - hence
 "uni-temporal".
 
-[Table inheritance](https://www.postgresql.org/docs/14/ddl-inherit.html) is a feature of PostgreSQL
-that allows a table to inherit all columns of a parent table. The descendant table’s schema will
-stay in sync with its parent. If a new column is added to or removed from the parent, the schema
-change is reflected on its descendants.
+[Table inheritance](https://www.postgresql.org/docs/current/ddl-inherit.html) is a feature of
+PostgreSQL that allows a table to inherit all columns of a parent table. The descendant table’s
+schema will stay in sync with its parent. If a new column is added to or removed from the parent,
+the schema change is reflected on its descendants.
 
 With these concepts combined, `hoardable` offers a model versioning and soft deletion system for
 Rails. Versions of records are stored in separate, inherited tables along with their valid time
@@ -143,11 +143,12 @@ Including `Hoardable::Model` into your source model modifies its default scope t
 query the parent table:
 
 ```ruby
-Post.where(state: :draft).to_sql # => SELECT posts.* FROM posts WHERE posts.tableoid = CAST('posts' AS regclass) AND posts.status = 'draft'
+Post.where(state: :draft).to_sql # => SELECT posts.* FROM ONLY posts WHERE posts.status = 'draft'
 ```
 
-_*Note*:_ If you are executing raw SQL, you will need to include this clause if you do not wish to
-return versions in the results.
+_*Note*:_ If you are executing raw SQL, you will need to include the `ONLY` keyword you see above to
+the select statement if you do not wish to return versions in the results. Learn more about table
+inheritance in [the PostgreSQL documentation](https://www.postgresql.org/docs/current/ddl-inherit.html).
 
 Since a `PostVersion` is an `ActiveRecord` class, you can query them like another model resource:
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,6 @@ bin/rails g hoardable:install
 bin/rails db:migrate
 ```
 
-This will generate PostgreSQL functions, an enum and an initiailzer. It will also set
-`config.active_record.schema_format = :sql` in `application.rb` if you are using Rails < 7.
-
 ### Model Installation
 
 You must include `Hoardable::Model` into an ActiveRecord model that you would like to hoard versions
@@ -510,8 +507,6 @@ proprietary JSON format directly on the database row of the record itself. If do
 deletion.
 
 ## Contributing
-
-This gem still quite new and very open to feedback.
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/waymondo/hoardable.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hoardable ![gem version](https://img.shields.io/gem/v/hoardable?style=flat-square)
 
-Hoardable is an ActiveRecord extension for Ruby 2.7+, Rails 6.1+, and PostgreSQL that allows for
+Hoardable is an ActiveRecord extension for Ruby 3+, Rails 7+, and PostgreSQL that allows for
 versioning and soft-deletion of records through the use of _uni-temporal inherited tables_.
 
 [Temporal tables](https://en.wikipedia.org/wiki/Temporal_database) are a database design pattern

--- a/Rakefile
+++ b/Rakefile
@@ -9,8 +9,4 @@ Rake::TestTask.new(:test) do |t|
   t.test_files = FileList['test/**/test_*.rb']
 end
 
-require 'rubocop/rake_task'
-
-RuboCop::RakeTask.new
-
-task default: %i[test rubocop]
+task default: %i[test]

--- a/bin/console
+++ b/bin/console
@@ -2,6 +2,6 @@
 # frozen_string_literal: true
 
 require 'irb'
-require_relative '../test/test_helper'
+require_relative '../test/helper'
 
 IRB.start(__FILE__)

--- a/lib/generators/hoardable/install_generator.rb
+++ b/lib/generators/hoardable/install_generator.rb
@@ -8,7 +8,6 @@ module Hoardable
   class InstallGenerator < Rails::Generators::Base
     source_root File.expand_path('templates', __dir__)
     include Rails::Generators::Migration
-    delegate :supports_schema_enums?, to: :class
 
     def create_initializer_file
       create_file(
@@ -23,12 +22,6 @@ module Hoardable
       )
     end
 
-    def change_schema_format_to_sql
-      return if supports_schema_enums?
-
-      application 'config.active_record.schema_format = :sql'
-    end
-
     def create_migration_file
       migration_template 'install.rb.erb', 'db/migrate/install_hoardable.rb'
     end
@@ -38,10 +31,6 @@ module Hoardable
         file_name = file_path.match(%r{([^/]+)\.sql})[1]
         template file_path, "db/functions/#{file_name}_v01.sql"
       end
-    end
-
-    def self.supports_schema_enums?
-      ActiveRecord.version >= ::Gem::Version.new('7.0.0')
     end
 
     def self.next_migration_number(dir)

--- a/lib/generators/hoardable/templates/install.rb.erb
+++ b/lib/generators/hoardable/templates/install.rb.erb
@@ -5,30 +5,6 @@ class InstallHoardable < ActiveRecord::Migration[<%= ActiveRecord::Migration.cur
     create_function :hoardable_prevent_update_id
     create_function :hoardable_source_set_id
     create_function :hoardable_version_prevent_update
-    <% if supports_schema_enums? %>
     create_enum :hoardable_operation, %w[update delete insert]
-    <% else %>
-    reversible do |dir|
-      dir.up do
-        execute(
-          <<~SQL.squish
-            DO $$
-            BEGIN
-              IF NOT EXISTS (
-                SELECT 1 FROM pg_type t WHERE t.typname = 'hoardable_operation'
-              ) THEN
-                CREATE TYPE hoardable_operation AS ENUM ('update', 'delete', 'insert');
-              END IF;
-            END
-            $$;
-          SQL
-        )
-      end
-
-      dir.down do
-        execute('DROP TYPE IF EXISTS hoardable_operation;')
-      end
-    end
-    <% end %>
   end
 end

--- a/lib/hoardable/engine.rb
+++ b/lib/hoardable/engine.rb
@@ -37,9 +37,6 @@ module Hoardable
   SUPPORTS_ENCRYPTED_ACTION_TEXT = ActiveRecord.version >= ::Gem::Version.new('7.0.4')
   private_constant :SUPPORTS_ENCRYPTED_ACTION_TEXT
 
-  SUPPORTS_VIRTUAL_COLUMNS = ActiveRecord.version >= ::Gem::Version.new('7.0.0')
-  private_constant :SUPPORTS_VIRTUAL_COLUMNS
-
   @context = {}
   @config = CONFIG_KEYS.to_h do |key|
     [key, true]

--- a/lib/hoardable/has_many.rb
+++ b/lib/hoardable/has_many.rb
@@ -16,11 +16,6 @@ module Hoardable
 
       def hoardable_scope
         if Hoardable.instance_variable_get('@at') && (hoardable_id = @association.owner.hoardable_id)
-          if @association.reflection.is_a?(ActiveRecord::Reflection::ThroughReflection)
-            @association.reflection.source_reflection.instance_variable_set(
-              '@active_record_primary_key', 'hoardable_id'
-            )
-          end
           @association.scope.rewhere(@association.reflection.foreign_key => hoardable_id)
         else
           @association.scope

--- a/lib/hoardable/scopes.rb
+++ b/lib/hoardable/scopes.rb
@@ -56,7 +56,7 @@ module Hoardable
             Arel::Nodes::Union.new(
               include_versions.where(id: version_class.at(datetime).select(primary_key)).arel,
               exclude_versions
-                .where("#{table_name}.created_at < ?", datetime)
+                .where(created_at: ..datetime)
                 .where.not(id: version_class.select(:hoardable_id).where(DURING_QUERY, datetime)).arel,
             ),
             arel_table

--- a/lib/hoardable/version.rb
+++ b/lib/hoardable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hoardable
-  VERSION = '0.14.3'
+  VERSION = '0.15.0'
 end

--- a/lib/hoardable/version_model.rb
+++ b/lib/hoardable/version_model.rb
@@ -13,13 +13,6 @@ module Hoardable
       def version_class
         self
       end
-
-      # This is needed to omit the pseudo row of 'tableoid' when using +ActiveRecord+’s +insert+.
-      #
-      # @!visibility private
-      def scope_attributes
-        super.without('tableoid')
-      end
     end
 
     included do

--- a/lib/hoardable/version_model.rb
+++ b/lib/hoardable/version_model.rb
@@ -127,7 +127,7 @@ module Hoardable
     def hoardable_source_attributes
       attributes.without(
         (self.class.column_names - self.class.superclass.column_names) +
-        (SUPPORTS_VIRTUAL_COLUMNS ? self.class.columns.select(&:virtual?).map(&:name) : [])
+        self.class.columns.select(&:virtual?).map(&:name)
       )
     end
   end

--- a/lib/hoardable/version_model.rb
+++ b/lib/hoardable/version_model.rb
@@ -79,7 +79,7 @@ module Hoardable
 
       transaction do
         hoardable_source.tap do |reverted|
-          reverted.reload.update!(hoardable_source_attributes.without(self.class.superclass.primary_key))
+          reverted.reload.update!(hoardable_source_attributes.without(self.class.superclass.primary_key, 'hoardable_id'))
           reverted.instance_variable_set(:@hoardable_version, self)
           reverted.run_callbacks(:reverted)
         end

--- a/lib/hoardable/version_model.rb
+++ b/lib/hoardable/version_model.rb
@@ -79,7 +79,9 @@ module Hoardable
 
       transaction do
         hoardable_source.tap do |reverted|
-          reverted.reload.update!(hoardable_source_attributes.without(self.class.superclass.primary_key, 'hoardable_id'))
+          reverted.reload.update!(
+            hoardable_source_attributes.without(self.class.superclass.primary_key, 'hoardable_id')
+          )
           reverted.instance_variable_set(:@hoardable_version, self)
           reverted.run_callbacks(:reverted)
         end

--- a/sig/hoardable.rbs
+++ b/sig/hoardable.rbs
@@ -30,14 +30,7 @@ module Hoardable
   end
 
   module Scopes
-    TABLEOID_AREL_CONDITIONS: Proc
     self.@klass: bot
-
-    private
-    def tableoid: -> untyped
-
-    public
-    attr_writer tableoid: untyped
   end
 
   class Error < StandardError

--- a/test/config/application.rb
+++ b/test/config/application.rb
@@ -8,4 +8,5 @@ class Dummy < Rails::Application
   config.paths['db/migrate'] = ['tmp/db/migrate']
   config.active_record.encryption&.key_derivation_salt = SecureRandom.hex
   config.active_record.encryption&.primary_key = SecureRandom.hex
+  config.active_record.yaml_column_permitted_classes = [ActiveSupport::HashWithIndifferentAccess]
 end

--- a/test/config/application.rb
+++ b/test/config/application.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require 'active_model/railtie'
+require 'active_record/railtie'
+require 'action_text/engine'
+
 class Dummy < Rails::Application
   config.load_defaults Rails::VERSION::STRING.to_f
   config.eager_load = false

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -6,7 +6,6 @@ require 'bundler/setup'
 require 'debug'
 require 'rails'
 require 'minitest/autorun'
-require 'minitest/spec'
 
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'hoardable'
@@ -18,15 +17,10 @@ end
 
 FileUtils.rm_f Dir.glob("#{tmp_dir}/**/*")
 
-require 'active_model/railtie'
-require 'active_record/railtie'
-require 'action_text/engine'
-
 require_relative 'config/application'
 Rails.initialize!
 
 SUPPORTS_ENCRYPTED_ACTION_TEXT = ActiveRecord.version >= Gem::Version.new('7.0.4')
-SUPPORTS_VIRTUAL_COLUMNS = ActiveRecord.version >= Gem::Version.new('7.0.0')
 
 require_relative 'support/models'
 require_relative 'support/database'

--- a/test/install_generator_test.rb
+++ b/test/install_generator_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require 'helper'
 
 class InstallGeneratorTest < Rails::Generators::TestCase
   tests Hoardable::InstallGenerator

--- a/test/support/database.rb
+++ b/test/support/database.rb
@@ -12,14 +12,8 @@ def truncate_db
   end
 end
 
-ActiveRecord::Base.connection.tables.each do |table|
-  next unless ActiveRecord::Base.connection.table_exists?(table)
-
-  ActiveRecord::Base.connection.drop_table(table, force: :cascade)
-end
-
 ActiveRecord::Schema.define do
-  create_table :posts do |t|
+  create_table :posts, if_not_exists: true do |t|
     t.text :body
     t.string :uuid, null: false, default: -> { 'gen_random_uuid()' }
     t.string :title, null: false
@@ -29,51 +23,51 @@ ActiveRecord::Schema.define do
     t.timestamps
   end
 
-  create_table :profiles do |t|
+  create_table :profiles, if_not_exists: true do |t|
     t.string :email, null: false
     t.bigint :user_id, null: false, index: true
     t.timestamps
   end
 
-  create_table :libraries, id: :uuid, default: -> { 'gen_random_uuid()' } do |t|
+  create_table :libraries, if_not_exists: true, id: :uuid, default: -> { 'gen_random_uuid()' } do |t|
     t.string :name, null: false
     t.timestamps
   end
 
-  create_table :books, id: :uuid, default: -> { 'gen_random_uuid()' } do |t|
+  create_table :books, if_not_exists: true, id: :uuid, default: -> { 'gen_random_uuid()' } do |t|
     t.string :title, null: false
     t.uuid :library_id, null: false, index: true
     t.timestamps
   end
 
-  create_table :tags, id: false do |t|
+  create_table :tags, if_not_exists: true, id: false do |t|
     t.string :name
     t.integer :primary_id, null: false, primary_key: true
     t.timestamps
   end
 
-  create_table :comments do |t|
+  create_table :comments, if_not_exists: true do |t|
     t.text :body
     t.bigint :post_id, null: false, index: true
     t.timestamps
   end
 
-  create_table :likes do |t|
+  create_table :likes, if_not_exists: true do |t|
     t.bigint :comment_id, null: false, index: true
     t.timestamps
   end
 
-  create_table :users do |t|
+  create_table :users, if_not_exists: true do |t|
     t.string :name, null: false
     t.text :preferences, default: '{}'
     t.timestamps
   end
 
-  create_table :bookmarks do |t|
+  create_table :bookmarks, if_not_exists: true do |t|
     t.string :name, null: false
   end
 
-  create_table :active_storage_blobs do |t|
+  create_table :active_storage_blobs, if_not_exists: true do |t|
     t.string   :key, null: false
     t.string   :filename, null: false
     t.string   :content_type
@@ -85,7 +79,7 @@ ActiveRecord::Schema.define do
     t.index [:key], unique: true
   end
 
-  create_table :active_storage_attachments do |t|
+  create_table :active_storage_attachments, if_not_exists: true do |t|
     t.string     :name,     null: false
     t.references :record,   null: false, polymorphic: true, index: false, type: :bigint
     t.references :blob,     null: false, type: :bigint
@@ -98,14 +92,14 @@ ActiveRecord::Schema.define do
     t.foreign_key :active_storage_blobs, column: :blob_id
   end
 
-  create_table :active_storage_variant_records do |t|
+  create_table :active_storage_variant_records, if_not_exists: true do |t|
     t.belongs_to :blob, null: false, index: false, type: :bigint
     t.string :variation_digest, null: false
     t.index %i[blob_id variation_digest], name: :index_active_storage_variant_records_uniqueness, unique: true
     t.foreign_key :active_storage_blobs, column: :blob_id
   end
 
-  create_table :action_text_rich_texts do |t|
+  create_table :action_text_rich_texts, if_not_exists: true do |t|
     t.string :name, null: false
     t.text :body
     t.references :record, null: false, polymorphic: true, index: false, type: :bigint

--- a/test/support/database.rb
+++ b/test/support/database.rb
@@ -107,7 +107,7 @@ ActiveRecord::Schema.define do
 
   create_table :action_text_rich_texts do |t|
     t.string :name, null: false
-    t.text       :body, size: :long
+    t.text :body
     t.references :record, null: false, polymorphic: true, index: false, type: :bigint
 
     t.timestamps

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -66,7 +66,7 @@ class User < ActiveRecord::Base
   has_many :posts
   has_one :profile, hoardable: true
   has_rich_text :bio, hoardable: true
-  serialize :preferences, JSON
+  serialize :preferences, coder: JSON
 end
 
 class Profile < ActiveRecord::Base

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,7 +22,7 @@ require 'active_model/railtie'
 require 'active_record/railtie'
 require 'action_text/engine'
 
-require 'config/application'
+require_relative 'config/application'
 Rails.initialize!
 
 SUPPORTS_ENCRYPTED_ACTION_TEXT = ActiveRecord.version >= Gem::Version.new('7.0.4')

--- a/test/test_hoardable.rb
+++ b/test/test_hoardable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require 'helper'
 
 class TestHoardable < Minitest::Test
   def test_that_it_has_a_version_number

--- a/test/test_migration_generator.rb
+++ b/test/test_migration_generator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require 'helper'
 
 class MigrationGeneratorTest < Rails::Generators::TestCase
   extend Minitest::Spec::DSL

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -67,8 +67,8 @@ class TestModel < Minitest::Test
   end
 
   it 'works with serialized attributes' do
-    user = User.create!(name: 'Joe Schmoe', preferences: { alerts: 'on' })
-    user.update!(preferences: { alerts: 'off' })
+    user = User.create!(name: 'Joe Schmoe', preferences: { 'alerts' => 'on' })
+    user.update!(preferences: { 'alerts' => 'off' })
     assert_equal user.versions.last.preferences, { 'alerts' => 'on' }
     user.destroy!
     user.versions.last.untrash!
@@ -124,10 +124,13 @@ class TestModel < Minitest::Test
   end
 
   it 'cannot change hoardable_id' do
-    post.update!(hoardable_id: 123)
     assert_equal post.reload.hoardable_id, post.id
+    if ActiveRecord.version >= Gem::Version.new('7.1')
+      assert_raises ActiveRecord::ReadonlyAttributeError do
+        post.update!(hoardable_id: 123)
+      end
+    end
     assert_raises(ActiveRecord::ActiveRecordError) { post.update_column(:hoardable_id, 123) }
-    assert_equal post.reload.hoardable_id, post.id
     assert_raises(ActiveRecord::StatementInvalid) do
       post.class.connection.execute('UPDATE posts SET hoardable_id = 123')
     end

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -507,9 +507,9 @@ class TestModel < Minitest::Test
       post = Post.find(post_id)
       assert_equal post.comments.pluck('body'), ['Comment']
       comment = post.comments.first
-      assert_equal Like.all.size, 2
-      assert_equal comment.likes.size, 2
-      assert_equal post.likes.size, 2
+      assert_equal 2, Like.all.size
+      assert_equal 2, comment.likes.size
+      assert_equal 2, post.likes.size
     end
   end
 

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require 'helper'
 
 class TestModel < Minitest::Test
   extend Minitest::Spec::DSL
 
-  before { truncate_db }
+  before do
+    ActiveRecord::Base.connection.tables.each do |table|
+      ActiveRecord::Base.connection.execute("TRUNCATE #{table} RESTART IDENTITY CASCADE")
+    end
+  end
 
   let(:user) { User.create!(name: 'Justin') }
 
@@ -34,7 +38,7 @@ class TestModel < Minitest::Test
     version = post.versions.first
     assert_equal version.status, 'draft'
     assert_equal version.title, 'Headline'
-    assert_equal version.lowercase_title, 'headline' if SUPPORTS_VIRTUAL_COLUMNS
+    assert_equal version.lowercase_title, 'headline'
   end
 
   it 'uses current db version and not the current ruby attribute value for version' do


### PR DESCRIPTION
changes the default scoping clause that controls the inherited table SQL construction from a where clause using `tableoid`s to using `FROM ONLY`. this comes as a simplification, but is more performant as it can avoid sequential scans on the version tables. see [this issue](https://github.com/waymondo/hoardable/issues/30) for more information.

this version bump also drops support for Ruby 2.7 and Rails 6.1

closes #30	