### PR TITLE
rails 7.1 test suite

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
           - "3.2"
         rails: 
           - "7.0"
-          # - "7.1"
+          - "7.1"
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - *Breaking Change* - Support for Ruby 2.7 and Rails 6.1 is dropped
 - *Breaking Change* - The default scoping clause that controls the inherited table SQL construction
   changes from a where clause using `tableoid`s to using `FROM ONLY`.
+- fixes an issue for Rails 7.1 regarding accessing version table columns through aliased attributes
 
 ## 0.14.3
 

--- a/lib/hoardable/version_model.rb
+++ b/lib/hoardable/version_model.rb
@@ -27,9 +27,12 @@ module Hoardable
       self.table_name = "#{table_name.singularize}#{VERSION_TABLE_SUFFIX}"
 
       alias_method :readonly?, :persisted?
-      alias_attribute :hoardable_operation, :_operation
-      alias_attribute :hoardable_event_uuid, :_event_uuid
-      alias_attribute :hoardable_during, :_during
+
+      [:operation, :event_uuid, :during].each do |symbol|
+        define_method("hoardable_#{symbol}") do
+          public_send("_#{symbol}")
+        end
+      end
 
       # @!scope class
       # @!method trashed

--- a/test/config/application.rb
+++ b/test/config/application.rb
@@ -7,7 +7,8 @@ require 'action_text/engine'
 class Dummy < Rails::Application
   config.load_defaults Rails::VERSION::STRING.to_f
   config.eager_load = false
-  config.active_storage.service_configurations = {}
+  config.active_storage.service_configurations = { local: { service: "Disk", root: "tmp/storage" } }
+  config.active_storage.service = :local
   config.paths['config/database'] = ['test/config/database.yml']
   config.paths['db/migrate'] = ['tmp/db/migrate']
   config.active_record.encryption&.key_derivation_salt = SecureRandom.hex


### PR DESCRIPTION
enables the test suite for rails 7.1. also fixes a 7.1 issue where `alias_attribute` didn't work as expected for db columns that only existed on the version tables