### PR TITLE
add monkey patch for joining with `ONLY` keyword

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,12 +10,11 @@ Rake::TestTask.new(:test) do |t|
   t.test_files = FileList["test/**/test_*.rb"]
 end
 
-SOURCE_FILES = %w[**/*.rb Rakefile Gemfile bin/console]
+SOURCE_FILES = %w[test/**/*.rb lib/**/*.rb Rakefile Gemfile bin/console hoardable.gemspec]
 
 SyntaxTree::Rake::CheckTask.new(:check) do |t|
   t.source_files = SOURCE_FILES
   t.print_width = 100
-  t.ignore_files = "vendor/**/*.rb"
 end
 
 SyntaxTree::Rake::WriteTask.new(:write) do |t|

--- a/hoardable.gemspec
+++ b/hoardable.gemspec
@@ -1,36 +1,39 @@
 # frozen_string_literal: true
 
-require_relative 'lib/hoardable/version'
+require_relative "lib/hoardable/version"
 
 Gem::Specification.new do |spec|
-  spec.name = 'hoardable'
+  spec.name = "hoardable"
   spec.version = Hoardable::VERSION
-  spec.authors = ['justin talbott']
-  spec.email = ['justin@waymondo.com']
+  spec.authors = ["justin talbott"]
+  spec.email = ["justin@waymondo.com"]
 
-  spec.summary = 'An ActiveRecord extension for versioning and soft-deletion of records in Postgres'
-  spec.description = 'Rails model versioning with the power of uni-temporal inherited tables'
-  spec.homepage = 'https://github.com/waymondo/hoardable'
-  spec.license = 'MIT'
-  spec.required_ruby_version = '>= 2.7.0'
+  spec.summary = "An ActiveRecord extension for versioning and soft-deletion of records in Postgres"
+  spec.description = "Rails model versioning with the power of uni-temporal inherited tables"
+  spec.homepage = "https://github.com/waymondo/hoardable"
+  spec.license = "MIT"
+  spec.required_ruby_version = ">= 3.0"
 
-  spec.metadata['homepage_uri'] = spec.homepage
-  spec.metadata['source_code_uri'] = spec.homepage
-  spec.metadata['rubygems_mfa_required'] = 'true'
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = spec.homepage
+  spec.metadata["rubygems_mfa_required"] = "true"
 
-  spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject do |f|
-      (f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features)/|\.(?:git|travis|circleci)|appveyor)})
+  spec.files =
+    Dir.chdir(File.expand_path(__dir__)) do
+      `git ls-files -z`.split("\x0")
+        .reject do |f|
+          (f == __FILE__) ||
+            f.match(%r{\A(?:(?:bin|test|spec|features)/|\.(?:git|travis|circleci)|appveyor)})
+        end
     end
-  end
-  spec.bindir = 'exe'
+  spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
-  spec.require_paths = ['lib']
+  spec.require_paths = ["lib"]
 
-  spec.add_dependency 'activerecord', '>= 6.1', '< 8'
-  spec.add_dependency 'activesupport', '>= 6.1', '< 8'
-  spec.add_dependency 'railties', '>= 6.1', '< 8'
+  spec.add_dependency "activerecord", ">= 7", "< 8"
+  spec.add_dependency "activesupport", ">= 7", "< 8"
+  spec.add_dependency "railties", ">= 7", "< 8"
 
-  spec.add_dependency 'fx', '>= 0.8', '< 1'
-  spec.add_dependency 'pg', '>= 1', '< 2'
+  spec.add_dependency "fx", ">= 0.8", "< 1"
+  spec.add_dependency "pg", ">= 1", "< 2"
 end

--- a/lib/hoardable.rb
+++ b/lib/hoardable.rb
@@ -3,6 +3,7 @@
 require "active_record"
 require "fx"
 require_relative "hoardable/version"
+require_relative "hoardable/arel_visitors"
 require_relative "hoardable/engine"
 require_relative "hoardable/finder_methods"
 require_relative "hoardable/scopes"

--- a/lib/hoardable/arel_visitors.rb
+++ b/lib/hoardable/arel_visitors.rb
@@ -1,0 +1,51 @@
+module Hoardable
+  # This is a monkey patch of JOIN related {Arel::Visitors} for PostgreSQL so that they can append
+  # the ONLY clause when known to be operating on a {Hoardable::Model}. Ideally, {Arel} itself would
+  # support this.
+  module ArelVisitors
+    def visit_Arel_Nodes_FullOuterJoin(o, collector)
+      collector << "FULL OUTER JOIN "
+      hoardable_maybe_add_only(o, collector)
+      collector = visit o.left, collector
+      collector << " "
+      visit o.right, collector
+    end
+
+    def visit_Arel_Nodes_OuterJoin(o, collector)
+      collector << "LEFT OUTER JOIN "
+      hoardable_maybe_add_only(o, collector)
+      collector = visit o.left, collector
+      collector << " "
+      visit o.right, collector
+    end
+
+    def visit_Arel_Nodes_RightOuterJoin(o, collector)
+      collector << "RIGHT OUTER JOIN "
+      hoardable_maybe_add_only(o, collector)
+      collector = visit o.left, collector
+      collector << " "
+      visit o.right, collector
+    end
+
+    def visit_Arel_Nodes_InnerJoin(o, collector)
+      collector << "INNER JOIN "
+      hoardable_maybe_add_only(o, collector)
+      collector = visit o.left, collector
+      if o.right
+        collector << " "
+        visit(o.right, collector)
+      else
+        collector
+      end
+    end
+
+    private def hoardable_maybe_add_only(o, collector)
+      return unless o.left.instance_variable_get("@klass").in?(Hoardable::REGISTRY)
+      return if Hoardable.instance_variable_get("@at")
+
+      collector << "ONLY "
+    end
+  end
+end
+
+Arel::Visitors::PostgreSQL.prepend Hoardable::ArelVisitors

--- a/lib/hoardable/arel_visitors.rb
+++ b/lib/hoardable/arel_visitors.rb
@@ -1,7 +1,7 @@
 module Hoardable
   # This is a monkey patch of JOIN related {Arel::Visitors} for PostgreSQL so that they can append
   # the ONLY clause when known to be operating on a {Hoardable::Model}. Ideally, {Arel} itself would
-  # support this.
+  # provide a mechanism to support this keyword.
   module ArelVisitors
     def visit_Arel_Nodes_FullOuterJoin(o, collector)
       collector << "FULL OUTER JOIN "

--- a/lib/hoardable/engine.rb
+++ b/lib/hoardable/engine.rb
@@ -2,6 +2,8 @@
 
 # An +ActiveRecord+ extension for keeping versions of records in uni-temporal inherited tables.
 module Hoardable
+  REGISTRY = Set.new
+
   # Symbols for use with setting contextual data, when creating versions. See
   # {file:README.md#tracking-contextual-data README} for more.
   DATA_KEYS = %i[meta whodunit event_uuid].freeze

--- a/lib/hoardable/has_many.rb
+++ b/lib/hoardable/has_many.rb
@@ -12,9 +12,7 @@ module Hoardable
         @scope ||= hoardable_scope
       end
 
-      private
-
-      def hoardable_scope
+      private def hoardable_scope
         if Hoardable.instance_variable_get("@at") &&
              (hoardable_id = @association.owner.hoardable_id)
           @association.scope.rewhere(@association.reflection.foreign_key => hoardable_id)

--- a/lib/hoardable/model.rb
+++ b/lib/hoardable/model.rb
@@ -67,6 +67,7 @@ module Hoardable
             object_namespace.const_set(version_class_name, Class.new(self) { include VersionModel })
           end
           include SourceModel
+          REGISTRY.add(self)
 
           trace.disable
         end

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -57,7 +57,7 @@ end
 
 class User < ActiveRecord::Base
   include Hoardable::Model
-  has_many :posts
+  has_many :posts, hoardable: true
   has_one :profile, hoardable: true
   has_rich_text :bio, hoardable: true
   serialize :preferences, coder: JSON


### PR DESCRIPTION
it doesn't seem like there's a good way around the fact that currently `Arel` [isn't flexible about how SQL JOIN strings get constructed](https://github.com/rails/rails/blob/16ff9afb2e78346e51b8969b76fc6afcba69d860/activerecord/lib/arel/visitors/to_sql.rb#L549-L558) regarding allowing the `ONLY` keyword to be conditionally appended. ideally one day Arel might support this, but for now we can monkey patch these methods. it doesn't feel great, but these methods have been stable for many years at this point.

also includes a bit more noise regarding linting