### PR TITLE
load the `ActionText` class if it hasn’t been already

### DIFF
--- a/lib/hoardable/has_rich_text.rb
+++ b/lib/hoardable/has_rich_text.rb
@@ -15,6 +15,10 @@ module Hoardable
         return unless hoardable
 
         reflection_options = reflections["rich_text_#{name}"].options
+
+        # load the +ActionText+ class if it hasn’t been already
+        reflection_options[:class_name].constantize
+
         reflection_options[:class_name] = reflection_options[:class_name].sub(
           /^ActionText/,
           "Hoardable"


### PR DESCRIPTION
we can’t load our Hoardable RichText subclasses until the ActionText ones have been, but if ActionText hasn’t been loaded yet, the `has_rich_text` extension can fail due to being unaware of them:

https://github.com/waymondo/hoardable/blob/717c5d5f2fede025491eaaf59f80d8c1253d69e1/lib/hoardable/engine.rb#L95-L98

connect to https://github.com/waymondo/hoardable/issues/37