### PR TITLE
add `has_hoardable_rich_text` for `has_rich_text hoardable: true`

### DIFF
--- a/.streerc
+++ b/.streerc
@@ -1,0 +1,1 @@
+--print-width=100

--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ Then in your model include `Hoardable::Model` and provide the `hoardable: true` 
 class Post < ActiveRecord::Base
   include Hoardable::Model # or `Hoardable::Associations` if you don't need `PostVersion`
   has_rich_text :content, hoardable: true
+  # alternately, this could be `has_hoardable_rich_text :content`
 end
 ```
 

--- a/lib/hoardable/has_rich_text.rb
+++ b/lib/hoardable/has_rich_text.rb
@@ -6,12 +6,8 @@ module Hoardable
     extend ActiveSupport::Concern
 
     class_methods do
-      def has_rich_text(name, encrypted: false, hoardable: false)
-        if SUPPORTS_ENCRYPTED_ACTION_TEXT
-          super(name, encrypted: encrypted)
-        else
-          super(name)
-        end
+      def has_rich_text(name, hoardable: false, **opts)
+        super(name, **opts)
         return unless hoardable
 
         reflection_options = reflections["rich_text_#{name}"].options
@@ -23,6 +19,10 @@ module Hoardable
           /^ActionText/,
           "Hoardable"
         )
+      end
+
+      def has_hoardable_rich_text(name, **opts)
+        has_rich_text(name, hoardable: true, **opts)
       end
     end
   end

--- a/test/support/database.rb
+++ b/test/support/database.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+ActiveRecord::Schema.verbose = false
+
 ActiveRecord::Schema.define do
   create_table :posts, if_not_exists: true do |t|
     t.text :body

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -66,6 +66,8 @@ end
 class Profile < ActiveRecord::Base
   include Hoardable::Model
   belongs_to :user
+  has_hoardable_rich_text :life_story
+  has_hoardable_rich_text :diary, encrypted: true
 end
 
 class Comment < ActiveRecord::Base

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -592,6 +592,23 @@ class TestModel < ActiveSupport::TestCase
     end
   end
 
+  test "has_hoardable_rich_text works" do
+    profile = Profile.create!(user: user, email: "email@example.com", life_story: "<div>woke up</div>")
+    datetime = DateTime.now
+    profile.update!(life_story: "<div>went to sleep</div>")
+    assert_equal "woke up", profile.at(datetime).life_story.to_plain_text
+  end
+
+  if SUPPORTS_ENCRYPTED_ACTION_TEXT
+    test "has_hoardable_rich_text works for encrypted rich text" do
+      profile = Profile.create!(user: user, email: "email@example.com", diary: "<div>i'm happy</div>")
+      datetime = DateTime.now
+      profile.update!(diary: "<div>i'm sad</div>")
+      assert_equal "i'm happy", profile.at(datetime).diary.to_plain_text
+      assert profile.diary.encrypted_attribute?("body")
+    end
+  end
+
   test "returns correct polymoprhic association via temporal has one relationship" do
     user = User.create!(name: "Joe Schmoe", bio: "<div>Bio</div>")
     post = PostWithRichText.create!(title: "Title", content: "<div>Content</div>", user: user)

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -593,7 +593,8 @@ class TestModel < ActiveSupport::TestCase
   end
 
   test "has_hoardable_rich_text works" do
-    profile = Profile.create!(user: user, email: "email@example.com", life_story: "<div>woke up</div>")
+    profile =
+      Profile.create!(user: user, email: "email@example.com", life_story: "<div>woke up</div>")
     datetime = DateTime.now
     profile.update!(life_story: "<div>went to sleep</div>")
     assert_equal "woke up", profile.at(datetime).life_story.to_plain_text
@@ -601,7 +602,8 @@ class TestModel < ActiveSupport::TestCase
 
   if SUPPORTS_ENCRYPTED_ACTION_TEXT
     test "has_hoardable_rich_text works for encrypted rich text" do
-      profile = Profile.create!(user: user, email: "email@example.com", diary: "<div>i'm happy</div>")
+      profile =
+        Profile.create!(user: user, email: "email@example.com", diary: "<div>i'm happy</div>")
       datetime = DateTime.now
       profile.update!(diary: "<div>i'm sad</div>")
       assert_equal "i'm happy", profile.at(datetime).diary.to_plain_text


### PR DESCRIPTION
IDEs that use the [RDoc options from Rails' source](https://github.com/rails/rails/blob/6b93fff8af32ef5e91f4ec3cfffb081d0553faf0/actiontext/lib/action_text/attribute.rb#L29) can complain that it doesn't know about the `hoardable:` option. This provides an alternate way to define a Hoardable rich text relationship.

connect to https://github.com/waymondo/hoardable/issues/37