### PR TITLE
conditionally enable crypto during install based on PG version

### DIFF
--- a/lib/generators/hoardable/install_generator.rb
+++ b/lib/generators/hoardable/install_generator.rb
@@ -34,7 +34,12 @@ module Hoardable
 
     no_tasks do
       def postgres_version
-        ActiveRecord::Base.connection.select_value("SELECT VERSION()").match(/[0-9]{1,2}([,.][0-9]{1,2})?/)[0].to_f
+        ActiveRecord::Base
+          .connection
+          .select_value("SELECT VERSION()")
+          .match(/[0-9]{1,2}([,.][0-9]{1,2})?/)[
+          0
+        ].to_f
       end
     end
 

--- a/lib/generators/hoardable/install_generator.rb
+++ b/lib/generators/hoardable/install_generator.rb
@@ -32,6 +32,12 @@ module Hoardable
         end
     end
 
+    no_tasks do
+      def postgres_version
+        ActiveRecord::Base.connection.select_value("SELECT VERSION()").match(/[0-9]{1,2}([,.][0-9]{1,2})?/)[0].to_f
+      end
+    end
+
     def self.next_migration_number(dir)
       ::ActiveRecord::Generators::Base.next_migration_number(dir)
     end

--- a/lib/generators/hoardable/templates/install.rb.erb
+++ b/lib/generators/hoardable/templates/install.rb.erb
@@ -2,7 +2,8 @@
 
 class InstallHoardable < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
   def change
-    create_function :hoardable_prevent_update_id
+    <% if postgres_version < 13 %>enable_extension :pgcrypto
+    <% end %>create_function :hoardable_prevent_update_id
     create_function :hoardable_source_set_id
     create_function :hoardable_version_prevent_update
     create_enum :hoardable_operation, %w[update delete insert]

--- a/test/test_install_generator.rb
+++ b/test/test_install_generator.rb
@@ -2,7 +2,7 @@
 
 require "helper"
 
-class InstallGeneratorTest < Rails::Generators::TestCase
+class TestInstallGenerator < Rails::Generators::TestCase
   tests Hoardable::InstallGenerator
   destination tmp_dir
   setup :prepare_destination
@@ -11,14 +11,8 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     run_generator
     assert_file "config/initializers/hoardable.rb", /Hoardable.enabled = true/
     assert_migration "db/migrate/install_hoardable.rb" do |migration|
-      if Hoardable::InstallGenerator.supports_schema_enums?
-        assert_match(/create_enum :hoardable_operation, %w\[update delete insert\]/, migration)
-      else
-        assert_match(
-          /CREATE TYPE hoardable_operation AS ENUM \('update', 'delete', 'insert'\);/,
-          migration
-        )
-      end
+      assert_match(/create_enum :hoardable_operation, %w\[update delete insert\]/, migration)
+      assert_no_match(/enable_extension :pgcrypto/, migration)
     end
     assert_file(
       "db/functions/hoardable_source_set_id_v01.sql",


### PR DESCRIPTION
`gen_random_uuid()` is available by default in PG versions 13+, so we need to ensure it's enabled for older versions.

closes https://github.com/waymondo/hoardable/issues/39