### PR TITLE
feat: Add support for table alias when injecting ONLY clause

### DIFF
--- a/lib/hoardable/arel_visitors.rb
+++ b/lib/hoardable/arel_visitors.rb
@@ -40,10 +40,16 @@ module Hoardable
     end
 
     private def hoardable_maybe_add_only(o, collector)
-      return unless o.left.instance_variable_get("@klass").in?(Hoardable::REGISTRY)
-      return if Hoardable.instance_variable_get("@at")
+      left = o.left
 
-      collector << "ONLY "
+      if left.is_a?(Arel::Nodes::TableAlias)
+        hoardable_maybe_add_only(left, collector)
+      else
+        return unless left.instance_variable_get("@klass").in?(Hoardable::REGISTRY)
+        return if Hoardable.instance_variable_get("@at")
+
+        collector << "ONLY "
+      end
     end
   end
 end

--- a/lib/hoardable/version.rb
+++ b/lib/hoardable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hoardable
-  VERSION = "0.15.0"
+  VERSION = "0.15.1"
 end

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -84,6 +84,8 @@ end
 class UserWithTrashedPosts < ActiveRecord::Base
   self.table_name = "users"
   has_many :posts, -> { include_versions }, foreign_key: "user_id"
+
+  has_one :bio, class_name: "Profile", foreign_key: "user_id"
 end
 
 class Current < ActiveSupport::CurrentAttributes

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -663,4 +663,11 @@ class TestModel < ActiveSupport::TestCase
     assert_empty user.posts
     assert_empty User.joins(:posts)
   end
+
+  test "applys ONLY clause on joined relationship with aliased name" do
+    assert_equal(
+      "SELECT \"users\".* FROM \"users\" INNER JOIN ONLY \"profiles\" \"bio\" ON \"bio\".\"user_id\" = \"users\".\"id\" WHERE \"bio\".\"id\" = 999",
+      UserWithTrashedPosts.joins(:bio).where(bio: {id: 999}).to_sql
+    )
+  end
 end

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -667,7 +667,7 @@ class TestModel < ActiveSupport::TestCase
   test "applys ONLY clause on joined relationship with aliased name" do
     assert_equal(
       "SELECT \"users\".* FROM \"users\" INNER JOIN ONLY \"profiles\" \"bio\" ON \"bio\".\"user_id\" = \"users\".\"id\" WHERE \"bio\".\"id\" = 999",
-      UserWithTrashedPosts.joins(:bio).where(bio: {id: 999}).to_sql
+      UserWithTrashedPosts.joins(:bio).where(bio: { id: 999 }).to_sql
     )
   end
 end


### PR DESCRIPTION
First of all, great library. We've just recently been using it in production and are really enjoying it.

One thing I've noticed is that Hoardable is not correctly injecting the `ONLY` clause when using a table alias.

For example - using the test DB schema as an example:
```
has_one :bio, class_name: "Profile"
```

When building a query using this alias, the `ArelVisitors` monkey patch is silently ignoring it because `o.left` is a table alias, which needs to be recursed into.

Anyway, here is a PR to fix that so Hoardable can properly support using aliases. 👍 