### PR TITLE
feat: Support custom temporal upper bound with Hoardable.on

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,11 +239,11 @@ version.hoardable_operation # => "update"
 
 When calculating the temporal range for a given version, the default upper bound is `Time.now.utc`.
 
-You can, however, use the `Hoardable.on` class method to specify a custom upper bound for the time range. This allows
+You can, however, use the `Hoardable.travel_to` class method to specify a custom upper bound for the time range. This allows
 you to specify the datetime that a particular change should be recorded at by passing a block:
 
 ```ruby
-Hoardable.on(2.weeks.ago) do
+Hoardable.travel_to(2.weeks.ago) do
   post.destroy!
 end
 ```

--- a/README.md
+++ b/README.md
@@ -235,6 +235,21 @@ version.changes # => { "title"=> ["Title", "New Title"] }
 version.hoardable_operation # => "update"
 ```
 
+### Overriding the temporal range
+
+When calculating the temporal range for a given version, the default upper bound is `Time.now.utc`.
+
+You can, however, use the `Hoardable.on` class method to specify a custom upper bound for the time range. This allows
+you to specify the datetime that a particular change should be recorded at by passing a block:
+
+```ruby
+Hoardable.on(2.weeks.ago) do
+  post.destroy!
+end
+```
+
+Note: If the provided datetime pre-dates the calculated lower bound then an `InvalidTemporalUpperBoundError` will be raised.
+
 ### Model Callbacks
 
 Sometimes you might want to do something with a version after it gets inserted to the database. You

--- a/lib/hoardable/database_client.rb
+++ b/lib/hoardable/database_client.rb
@@ -93,7 +93,7 @@ module Hoardable
     end
 
     def initialize_temporal_range
-      upper_bound = Hoardable.instance_variable_get("@on") || Time.now.utc
+      upper_bound = Hoardable.instance_variable_get("@travel_to") || Time.now.utc
       lower_bound = (previous_temporal_tsrange_end || hoardable_source_epoch)
 
       if upper_bound < lower_bound

--- a/lib/hoardable/database_client.rb
+++ b/lib/hoardable/database_client.rb
@@ -93,7 +93,14 @@ module Hoardable
     end
 
     def initialize_temporal_range
-      ((previous_temporal_tsrange_end || hoardable_source_epoch)..Time.now.utc)
+      upper_bound = Hoardable.instance_variable_get("@on") || Time.now.utc
+      lower_bound = (previous_temporal_tsrange_end || hoardable_source_epoch)
+
+      if upper_bound < lower_bound
+        raise InvalidTemporalUpperBoundError.new(upper_bound, lower_bound)
+      end
+
+      (lower_bound..upper_bound)
     end
 
     def initialize_hoardable_data

--- a/lib/hoardable/engine.rb
+++ b/lib/hoardable/engine.rb
@@ -81,6 +81,16 @@ module Hoardable
       @at = nil
     end
 
+    # Allows calling code to set the upper bound for the temporal range for recorded audits.
+    #
+    # @param datetime [DateTime] the datetime to temporally record audits at
+    def on(datetime)
+      @on = datetime
+      yield
+    ensure
+      @on = nil
+    end
+
     # @!visibility private
     def logger
       @logger ||= ActiveSupport::TaggedLogging.new(Logger.new($stdout))

--- a/lib/hoardable/engine.rb
+++ b/lib/hoardable/engine.rb
@@ -84,11 +84,11 @@ module Hoardable
     # Allows calling code to set the upper bound for the temporal range for recorded audits.
     #
     # @param datetime [DateTime] the datetime to temporally record audits at
-    def on(datetime)
-      @on = datetime
+    def travel_to(datetime)
+      @travel_to = datetime
       yield
     ensure
-      @on = nil
+      @travel_to = nil
     end
 
     # @!visibility private

--- a/lib/hoardable/engine.rb
+++ b/lib/hoardable/engine.rb
@@ -83,7 +83,7 @@ module Hoardable
 
     # Allows calling code to set the upper bound for the temporal range for recorded audits.
     #
-    # @param datetime [DateTime] the datetime to temporally record audits at
+    # @param datetime [DateTime] the datetime to temporally record versions at
     def travel_to(datetime)
       @travel_to = datetime
       yield

--- a/lib/hoardable/error.rb
+++ b/lib/hoardable/error.rb
@@ -29,7 +29,7 @@ module Hoardable
   class InvalidTemporalUpperBoundError < Error
     def initialize(upper, lower)
       super(<<~LOG)
-          'The supplied value to `Hoardable.on` (#{upper}) is before the calculated lower bound (#{lower}).
+          'The supplied value to `Hoardable.travel_to` (#{upper}) is before the calculated lower bound (#{lower}).
           You must provide a datetime > the lower bound.
         LOG
     end

--- a/lib/hoardable/error.rb
+++ b/lib/hoardable/error.rb
@@ -24,4 +24,14 @@ module Hoardable
         LOG
     end
   end
+
+  # An error to be raised when the provided temporal upper bound is before the calcualated lower bound.
+  class InvalidTemporalUpperBoundError < Error
+    def initialize(upper, lower)
+      super(<<~LOG)
+          'The supplied value to `Hoardable.on` (#{upper}) is before the calculated lower bound (#{lower}).
+          You must provide a datetime > the lower bound.
+        LOG
+    end
+  end
 end

--- a/lib/hoardable/version.rb
+++ b/lib/hoardable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hoardable
-  VERSION = "0.16.0"
+  VERSION = "0.16.1"
 end

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -464,14 +464,14 @@ class TestModel < ActiveSupport::TestCase
     end
   end
 
-  test "can influence the upper bound of the temporal range with Hoardable.on" do
+  test "can influence the upper bound of the temporal range with Hoardable.travel_to" do
     created_at = Time.now.utc - 10 * 86_400 # 10 days ago
     deleted_at = Time.now.utc - 5 * 86_400 # 5 days ago
 
     comment =
       post.comments.create!(body: "Comment 1", created_at: created_at, updated_at: created_at)
 
-    Hoardable.on(deleted_at) { comment.destroy! }
+    Hoardable.travel_to(deleted_at) { comment.destroy! }
 
     temporal_range = CommentVersion.where(hoardable_id: comment.id).first._during
 
@@ -479,14 +479,14 @@ class TestModel < ActiveSupport::TestCase
     assert_equal temporal_range.max.round, deleted_at.round
   end
 
-  test "will error if the upper bound of the temporal range with Hoardable.on is less than the lower bound" do
+  test "will error if the upper bound of the temporal range with Hoardable.travel_to is less than the lower bound" do
     created_at = Time.now.utc - 10 * 86_400 # 10 days ago
     deleted_at = Time.now.utc - 12 * 86_400 # 12 days ago
 
     comment =
       post.comments.create!(body: "Comment 1", created_at: created_at, updated_at: created_at)
 
-    Hoardable.on(deleted_at) do
+    Hoardable.travel_to(deleted_at) do
       assert_raises(Hoardable::InvalidTemporalUpperBoundError) { comment.destroy! }
     end
 

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -474,7 +474,7 @@ class TestModel < ActiveSupport::TestCase
     Hoardable.on(deleted_at) { comment.destroy! }
 
     assert_equal Comment.all.size, 0
-    assert_equal CommentVersion.where(hoardable_id: comment.id).first._during.max, deleted_at
+    assert_equal CommentVersion.where(hoardable_id: comment.id).first._during.max.round, deleted_at.round
   end
 
   test "will error if the upper bound of the temporal range with Hoardable.on is less than the lower bound" do

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -473,8 +473,10 @@ class TestModel < ActiveSupport::TestCase
 
     Hoardable.on(deleted_at) { comment.destroy! }
 
+    temporal_range = CommentVersion.where(hoardable_id: comment.id).first._during
+
     assert_equal Comment.all.size, 0
-    assert_equal CommentVersion.where(hoardable_id: comment.id).first._during.max.round, deleted_at.round
+    assert_equal temporal_range.max.round, deleted_at.round
   end
 
   test "will error if the upper bound of the temporal range with Hoardable.on is less than the lower bound" do


### PR DESCRIPTION
This PR implements a `Hoardable.on` helper class method that allows calling code to influence the upper bound of the time range used to represent a change.

```ruby
post = Post.create(title: "Blah", created_at: 1.month.ago, updated_at: 1.month.ago)

Hoardable.on(2.weeks.ago) do
  post.destroy!
end

PostVersion.last._during.max # -> 2.weeks.ago
```

I am more than happy for feedback on implementation and naming on this one!

It's a relatively obscure feature, of course, but it's something we've already found ourselves having to do as we begin to roll Hoardable out into a relatively large, in-production Rails app.

So, having the ability to influence that generated upper bound so it doesn't always hardcode to `Time.now.utc` is really helpful :)