### PR TITLE
fix: Ensure the class name matches the file name in the migration generator

### DIFF
--- a/lib/generators/hoardable/templates/migration.rb.erb
+++ b/lib/generators/hoardable/templates/migration.rb.erb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Create<%= class_name.singularize.delete(':') %>Versions < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
+class Create<%= singularized_table_name.classify %>Versions < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
   def change
     add_column :<%= table_name %>, :hoardable_id, :<%= foreign_key_type %>
     add_index :<%= table_name %>, :hoardable_id

--- a/lib/hoardable/version.rb
+++ b/lib/hoardable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hoardable
-  VERSION = "0.17.0"
+  VERSION = "0.17.1"
 end


### PR DESCRIPTION
This fixes the bug in which the generator is called with a nested model as input.

Previous functionality would generate a class name that did not match the file name, which would cause a zeitwerk error.

For example:
```
class My::Nested::Model
  table_name :products
end
```
```
rails g hoardable:migration My::Nested::Model
```
This would use the table name to form the migration file name, but the class name to form the class name of the migration.

This PR is just a simple fix to ensure we use the table name in both the migration file name and the class name so they always match.

(FYI I am pretty sure I introduced this bug myself in a previous PR - sorry!)
