### PR TITLE
chore: Only disable has_many cache if hoardable option is specified

### DIFF
--- a/lib/hoardable/has_many.rb
+++ b/lib/hoardable/has_many.rb
@@ -26,18 +26,18 @@ module Hoardable
     class_methods do
       def has_many(*args, &block)
         options = args.extract_options!
-        options[:extend] = Array(options[:extend]).push(HasManyExtension) if options.delete(
-          :hoardable
-        )
+        hoardable_option = options.delete(:hoardable)
+        options[:extend] = Array(options[:extend]).push(HasManyExtension) if hoardable_option
+
         super(*args, **options, &block)
 
         # This hack is needed to force Rails to not use any existing method cache so that the
         # {HasManyExtension} scope is always used.
-        class_eval <<-RUBY, __FILE__, __LINE__ + 1
-          def #{args.first}
-            super.extending
-          end
-        RUBY
+        class_eval <<-RUBY, __FILE__, __LINE__ + 1 if hoardable_option or args.first == :versions
+            def #{args.first}
+              super.extending
+            end
+          RUBY
       end
     end
   end

--- a/lib/hoardable/version.rb
+++ b/lib/hoardable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hoardable
-  VERSION = "0.17.1"
+  VERSION = "0.18.0"
 end


### PR DESCRIPTION
Fixes https://github.com/waymondo/hoardable/issues/53

This ensures that the Rails `has_many` cache is used. This allows for `includes`, `joins`, etc optimisations on one-to-many relationships to prevent `N+1` queries.

The overload hack will only be defined if the `hoardable: true` option is specified on the association now.

I've opted for a minor version bump here considering it changes some underlying behaviour. Happy for guidance, though.

Note that - for reasons I don't fully understand - a couple of tests broke if we don't define the overload hack for the `:versions` association on the source model.