### PR TITLE
basic STI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,8 +332,8 @@ Model-level configuration overrides global configuration.
 Hoardable works for [Single Table
 Inheritance](https://guides.rubyonrails.org/association_basics.html#single-table-inheritance-sti). You
 will need to include `Hoardable::Model` in each child model you'd like to version, as that is what
-generates the model's version class. The migration generator does not need to be run as the versions
-will be stored in the same table.
+generates the model's version class. The migration generator only needs to be run for the parent
+model, as the versions will similarly be stored in a single table.
 
 ## Relationships
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Include `Hoardable::Model` into an ActiveRecord model you would like to hoard ve
 ```ruby
 class Post < ActiveRecord::Base
   include Hoardable::Model
-  ...
 end
 ```
 
@@ -327,6 +326,14 @@ end
 ```
 
 Model-level configuration overrides global configuration.
+
+### Single Table Inheritance
+
+Hoardable works for [Single Table
+Inheritance](https://guides.rubyonrails.org/association_basics.html#single-table-inheritance-sti). You
+will need to include `Hoardable::Model` in each child model you'd like to version, as that is what
+generates the model's version class. The migration generator does not need to be run as the versions
+will be stored in the same table.
 
 ## Relationships
 

--- a/lib/generators/hoardable/migration_generator.rb
+++ b/lib/generators/hoardable/migration_generator.rb
@@ -45,21 +45,24 @@ module Hoardable
         "hoardable_set_hoardable_id_from_#{primary_key}"
       end
 
+      def klass
+        @klass ||= class_name.singularize.constantize
+      end
+
       def table_name
-        class_name.singularize.constantize.table_name
+        klass.table_name
       rescue StandardError
         super
       end
 
       def foreign_key_type
-        options[:foreign_key_type] ||
-          class_name.singularize.constantize.columns.find { |col| col.name == primary_key }.sql_type
+        options[:foreign_key_type] || klass.columns.find { |col| col.name == primary_key }.sql_type
       rescue StandardError
         "bigint"
       end
 
       def primary_key
-        options[:primary_key] || class_name.singularize.constantize.primary_key
+        options[:primary_key] || klass.primary_key
       rescue StandardError
         "id"
       end

--- a/lib/hoardable/scopes.rb
+++ b/lib/hoardable/scopes.rb
@@ -9,13 +9,20 @@ module Hoardable
     included do
       # By default {Hoardable} only returns instances of the parent table, and not the +versions+ in
       # the inherited table. This can be bypassed by using the {.include_versions} scope or wrapping
-      # the code in a `Hoardable.at(datetime)` block.
+      # the code in a `Hoardable.at(datetime)` block. When this is a version class that is an STI
+      # model, also scope to them.
       default_scope do
-        if (hoardable_at = Hoardable.instance_variable_get("@at"))
-          at(hoardable_at)
-        else
-          exclude_versions
-        end
+        scope =
+          (
+            if (hoardable_at = Hoardable.instance_variable_get("@at"))
+              at(hoardable_at)
+            else
+              exclude_versions
+            end
+          )
+        next scope unless klass == version_class && "type".in?(column_names)
+
+        scope.where(type: superclass.sti_name)
       end
 
       # @!scope class

--- a/lib/hoardable/source_model.rb
+++ b/lib/hoardable/source_model.rb
@@ -44,16 +44,20 @@ module Hoardable
       end
 
       after_commit { hoardable_client.unset_hoardable_version_and_event_uuid }
+    end
 
-      # Returns all +versions+ in ascending order of their temporal timeframes.
-      has_many(
-        :versions,
-        -> { order("UPPER(_during) ASC") },
-        dependent: nil,
-        class_name: version_class.to_s,
-        inverse_of: :hoardable_source,
-        foreign_key: :hoardable_id
-      )
+    def self.included(base)
+      base.class_eval do
+        # Returns all +versions+ in ascending order of their temporal timeframes.
+        has_many(
+          :versions,
+          -> { order("UPPER(_during) ASC") },
+          dependent: nil,
+          class_name: version_class.to_s,
+          inverse_of: :hoardable_source,
+          foreign_key: :hoardable_id
+        )
+      end
     end
 
     # Returns a boolean of whether the record is actually a trashed +version+ cast as an instance of the

--- a/lib/hoardable/version.rb
+++ b/lib/hoardable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hoardable
-  VERSION = "0.18.0"
+  VERSION = "0.18.1"
 end

--- a/lib/hoardable/version_model.rb
+++ b/lib/hoardable/version_model.rb
@@ -24,6 +24,9 @@ module Hoardable
         class_name: superclass.model_name
       )
 
+      # disable STI on versions tables
+      self.inheritance_column = :_
+
       self.table_name = "#{table_name.singularize}#{VERSION_TABLE_SUFFIX}"
 
       alias_method :readonly?, :persisted?

--- a/test/support/database.rb
+++ b/test/support/database.rb
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define do
 
   create_table :books, if_not_exists: true, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
     t.string :title, null: false
+    t.string :type, null: false, default: "Book"
     t.uuid :library_id, null: false, index: true
     t.timestamps
   end

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -97,6 +97,14 @@ class Book < ActiveRecord::Base
   belongs_to :library
 end
 
+class Masterpiece < Book
+  include Hoardable::Model
+
+  def title
+    "#{super}!"
+  end
+end
+
 class Tag < ActiveRecord::Base
   include Hoardable::Model
   self.primary_key = "primary_id"


### PR DESCRIPTION
closes https://github.com/waymondo/hoardable/issues/51

adds basic support for [single table inheritance](https://guides.rubyonrails.org/association_basics.html#single-table-inheritance-sti). it does this by changing the parts that need to be re-evaluated in subclasses from using `ActiveSupport::Concern`'s `included` block, to using a regular call to the class's `included` method.