### PR TITLE
Feat: Allow for thread-safe configuration and context setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.19.0
+
+- Ensure that stateful Hoardable class methods `with`, `travel_to` and `at` are thread-safe.
+
 ## 0.18.2
 
 - Fix for using `update_all` with Hoardable records.

--- a/lib/hoardable/arel_visitors.rb
+++ b/lib/hoardable/arel_visitors.rb
@@ -46,7 +46,7 @@ module Hoardable
         hoardable_maybe_add_only(left, collector)
       else
         return unless left.instance_variable_get("@klass").in?(Hoardable::REGISTRY)
-        return if Hoardable.instance_variable_get("@at")
+        return if Thread.current[:at]
 
         collector << "ONLY "
       end

--- a/lib/hoardable/arel_visitors.rb
+++ b/lib/hoardable/arel_visitors.rb
@@ -46,7 +46,7 @@ module Hoardable
         hoardable_maybe_add_only(left, collector)
       else
         return unless left.instance_variable_get("@klass").in?(Hoardable::REGISTRY)
-        return if Thread.current[:at]
+        return if Thread.current[:hoardable_at]
 
         collector << "ONLY "
       end

--- a/lib/hoardable/database_client.rb
+++ b/lib/hoardable/database_client.rb
@@ -56,7 +56,7 @@ module Hoardable
     end
 
     def has_one_at_timestamp
-      Hoardable.instance_variable_get("@at") || source_record.updated_at
+      Thread.current[:at] || source_record.updated_at
     rescue NameError
       raise(UpdatedAtColumnMissingError, source_record.class.table_name)
     end
@@ -93,7 +93,7 @@ module Hoardable
     end
 
     def initialize_temporal_range
-      upper_bound = Hoardable.instance_variable_get("@travel_to") || Time.now.utc
+      upper_bound = Thread.current[:travel_to] || Time.now.utc
       lower_bound = (previous_temporal_tsrange_end || hoardable_source_epoch)
 
       if upper_bound < lower_bound

--- a/lib/hoardable/database_client.rb
+++ b/lib/hoardable/database_client.rb
@@ -56,7 +56,7 @@ module Hoardable
     end
 
     def has_one_at_timestamp
-      Thread.current[:at] || source_record.updated_at
+      Thread.current[:hoardable_at] || source_record.updated_at
     rescue NameError
       raise(UpdatedAtColumnMissingError, source_record.class.table_name)
     end
@@ -93,7 +93,7 @@ module Hoardable
     end
 
     def initialize_temporal_range
-      upper_bound = Thread.current[:travel_to] || Time.now.utc
+      upper_bound = Thread.current[:hoardable_travel_to] || Time.now.utc
       lower_bound = (previous_temporal_tsrange_end || hoardable_source_epoch)
 
       if upper_bound < lower_bound

--- a/lib/hoardable/engine.rb
+++ b/lib/hoardable/engine.rb
@@ -45,7 +45,7 @@ module Hoardable
   class << self
     CONFIG_KEYS.each do |key|
       define_method(key) do
-        local_config = Thread.current[:config] || @config
+        local_config = Thread.current[:hoardable_config] || @config
         local_config[key]
       end
 
@@ -54,7 +54,7 @@ module Hoardable
 
     DATA_KEYS.each do |key|
       define_method(key) do
-        local_context = Thread.current[:context] || @context
+        local_context = Thread.current[:hoardable_context] || @context
         local_context[key]
       end
 
@@ -67,12 +67,12 @@ module Hoardable
     # @param hash [Hash] config and contextual data to set within a block
     def with(hash)
       thread = Thread.current
-      thread[:config] = @config.merge(hash.slice(*CONFIG_KEYS))
-      thread[:context] = @context.merge(hash.slice(*DATA_KEYS))
+      thread[:hoardable_config] = @config.merge(hash.slice(*CONFIG_KEYS))
+      thread[:hoardable_context] = @context.merge(hash.slice(*DATA_KEYS))
       yield
     ensure
-      thread[:config] = nil
-      thread[:context] = nil
+      thread[:hoardable_config] = nil
+      thread[:hoardable_context] = nil
     end
 
     # Allows performing a query for record states at a certain time. Returned {SourceModel}
@@ -81,10 +81,10 @@ module Hoardable
     # @param datetime [DateTime, Time] the datetime or time to temporally query records at
     def at(datetime)
       thread = Thread.current
-      thread[:at] = datetime
+      thread[:hoardable_at] = datetime
       yield
     ensure
-      thread[:at] = nil
+      thread[:hoardable_at] = nil
     end
 
     # Allows calling code to set the upper bound for the temporal range for recorded audits.
@@ -92,10 +92,10 @@ module Hoardable
     # @param datetime [DateTime] the datetime to temporally record versions at
     def travel_to(datetime)
       thread = Thread.current
-      thread[:travel_to] = datetime
+      thread[:hoardable_travel_to] = datetime
       yield
     ensure
-      thread[:travel_to] = nil
+      thread[:hoardable_travel_to] = nil
     end
 
     # @!visibility private

--- a/lib/hoardable/engine.rb
+++ b/lib/hoardable/engine.rb
@@ -80,20 +80,22 @@ module Hoardable
     #
     # @param datetime [DateTime, Time] the datetime or time to temporally query records at
     def at(datetime)
-      @at = datetime
+      thread = Thread.current
+      thread[:at] = datetime
       yield
     ensure
-      @at = nil
+      thread[:at] = nil
     end
 
     # Allows calling code to set the upper bound for the temporal range for recorded audits.
     #
     # @param datetime [DateTime] the datetime to temporally record versions at
     def travel_to(datetime)
-      @travel_to = datetime
+      thread = Thread.current
+      thread[:travel_to] = datetime
       yield
     ensure
-      @travel_to = nil
+      thread[:travel_to] = nil
     end
 
     # @!visibility private

--- a/lib/hoardable/has_many.rb
+++ b/lib/hoardable/has_many.rb
@@ -13,7 +13,7 @@ module Hoardable
       end
 
       private def hoardable_scope
-        if Thread.current[:at]
+        if Thread.current[:hoardable_at]
           (hoardable_id = @association.owner.hoardable_id)
           @association.scope.rewhere(@association.reflection.foreign_key => hoardable_id)
         else
@@ -36,7 +36,7 @@ module Hoardable
         # {HasManyExtension} scope is always used when using {Hoardable.at}.
         class_eval <<-RUBY, __FILE__, __LINE__ + 1
           def #{args.first}
-            if Thread.current[:at]
+            if Thread.current[:hoardable_at]
               super.extending
             else
               super

--- a/lib/hoardable/has_many.rb
+++ b/lib/hoardable/has_many.rb
@@ -13,7 +13,7 @@ module Hoardable
       end
 
       private def hoardable_scope
-        if Hoardable.instance_variable_get("@at") &&
+        if Thread.current[:at]
              (hoardable_id = @association.owner.hoardable_id)
           @association.scope.rewhere(@association.reflection.foreign_key => hoardable_id)
         else
@@ -36,7 +36,7 @@ module Hoardable
         # {HasManyExtension} scope is always used when using {Hoardable.at}.
         class_eval <<-RUBY, __FILE__, __LINE__ + 1
           def #{args.first}
-            if Hoardable.instance_variable_get("@at")
+            if Thread.current[:at]
               super.extending
             else
               super

--- a/lib/hoardable/has_many.rb
+++ b/lib/hoardable/has_many.rb
@@ -14,7 +14,7 @@ module Hoardable
 
       private def hoardable_scope
         if Thread.current[:at]
-             (hoardable_id = @association.owner.hoardable_id)
+          (hoardable_id = @association.owner.hoardable_id)
           @association.scope.rewhere(@association.reflection.foreign_key => hoardable_id)
         else
           @association.scope

--- a/lib/hoardable/scopes.rb
+++ b/lib/hoardable/scopes.rb
@@ -14,7 +14,7 @@ module Hoardable
       default_scope do
         scope =
           (
-            if (hoardable_at = Thread.current[:at])
+            if (hoardable_at = Thread.current[:hoardable_at])
               at(hoardable_at)
             else
               exclude_versions

--- a/lib/hoardable/scopes.rb
+++ b/lib/hoardable/scopes.rb
@@ -14,7 +14,7 @@ module Hoardable
       default_scope do
         scope =
           (
-            if (hoardable_at = Hoardable.instance_variable_get("@at"))
+            if (hoardable_at = Thread.current[:at])
               at(hoardable_at)
             else
               exclude_versions

--- a/lib/hoardable/version.rb
+++ b/lib/hoardable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hoardable
-  VERSION = "0.18.2"
+  VERSION = "0.19.0"
 end


### PR DESCRIPTION
This adds support for thread-safety to Hoardable for:
  - `with`
  - `travel_to`
  - `at`
  
This is important because production apps will run multiple threads and currently any overloading of `config` or `context` data (`event_uuid`, `whodunit`, etc) will occur globally across all threads, which will lead to data leaks.

Fixes: https://github.com/waymondo/hoardable/issues/63