### PR TITLE
`event_uuid` tweaks

### DIFF
--- a/lib/hoardable/database_client.rb
+++ b/lib/hoardable/database_client.rb
@@ -28,9 +28,7 @@ module Hoardable
     end
 
     def find_or_initialize_hoardable_event_uuid
-      Thread.current[:hoardable_event_uuid] ||= (
-        ActiveRecord::Base.connection.query("SELECT gen_random_uuid();")[0][0]
-      )
+      Thread.current[:hoardable_event_uuid] ||= SecureRandom.uuid
     end
 
     def initialize_version_attributes(operation)

--- a/lib/hoardable/engine.rb
+++ b/lib/hoardable/engine.rb
@@ -6,7 +6,7 @@ module Hoardable
 
   # Symbols for use with setting contextual data, when creating versions. See
   # {file:README.md#tracking-contextual-data README} for more.
-  DATA_KEYS = %i[meta whodunit event_uuid].freeze
+  DATA_KEYS = %i[meta whodunit].freeze
 
   # Symbols for use with setting {Hoardable} configuration. See {file:README.md#configuration
   # README} for more.


### PR DESCRIPTION
it doesn't make sense to store store a null entry for `_event_uuid` on `_data`. hoardable's database client manages setting `_event_uuid` for all records in the same thread's transaction on it's own column. also, it doesn't make much sense to request postgres to generate a UUID for the event when we can do that directly with ruby.

connect to https://github.com/waymondo/hoardable/issues/66