### PR TITLE
thread safety for `with_hoardable_config`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.19.1
+
+- Thread-safety support added for `with_hoardable_config`.
+
 ## 0.19.0
 
 - Ensure that stateful Hoardable class methods `with`, `travel_to` and `at` are thread-safe.

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,12 @@
 
 source "https://rubygems.org"
 
+gem "bigdecimal"
 gem "debug"
+gem "drb"
+gem "logger"
+gem "mutex_m"
+gem "ostruct"
 if (rails_version = ENV["RAILS_VERSION"])
   gem "rails", "~> #{rails_version}"
 else

--- a/lib/hoardable/version.rb
+++ b/lib/hoardable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hoardable
-  VERSION = "0.19.0"
+  VERSION = "0.19.1"
 end

--- a/test/support/database.rb
+++ b/test/support/database.rb
@@ -133,6 +133,12 @@ def run_install_migration
   "InstallHoardable".constantize.migrate(:up)
 end
 
+def reset_db
+  ActiveRecord::Base.connection.tables.each do |table|
+    ActiveRecord::Base.connection.execute("TRUNCATE #{table} RESTART IDENTITY CASCADE")
+  end
+end
+
 run_install_migration
 generate_versions_table("Post")
 generate_versions_table("User")

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -3,9 +3,7 @@
 require "helper"
 
 class TestModel < ActiveSupport::TestCase
-  setup do
-    reset_db
-  end
+  setup { reset_db }
 
   private def user
     @user ||= User.create!(name: "Justin")

--- a/test/test_model.rb
+++ b/test/test_model.rb
@@ -4,9 +4,7 @@ require "helper"
 
 class TestModel < ActiveSupport::TestCase
   setup do
-    ActiveRecord::Base.connection.tables.each do |table|
-      ActiveRecord::Base.connection.execute("TRUNCATE #{table} RESTART IDENTITY CASCADE")
-    end
+    reset_db
   end
 
   private def user

--- a/test/test_thread_safety.rb
+++ b/test/test_thread_safety.rb
@@ -1,0 +1,58 @@
+require "helper"
+
+class TestThreadSafety < ActiveSupport::TestCase
+  private attr_reader :threads_count
+
+  setup do
+    @threads_count = 5
+  end
+
+  test "whodunnit respects thread-safety" do
+    threads =
+      threads_count.times.map do |i|
+        Thread.new do
+          Hoardable.with(whodunit: i) do
+            threads_count.times.map do
+              sleep(Random.new.rand(0.5))
+              Hoardable.whodunit
+            end
+          end
+        end
+      end
+
+    threads.each(&:join)
+
+    assert_equal(
+      Array.new(threads_count) { |i| Array.new(threads_count) { i } },
+      threads.map { |t| t.value }
+    )
+  end
+
+  test "with_hoardable_config respects thread-safety" do
+    reset_db
+
+    user = User.create!(name: "Joe Schmoe")
+
+    Array
+      .new(threads_count) do |i|
+        [
+          Thread.new do
+            sleep(Random.new.rand(0.5))
+
+            user.update!(name: "Joe #{i}")
+          end,
+          Thread.new do
+            User.with_hoardable_config(version_updates: false) do
+              sleep(Random.new.rand(0.5))
+
+              user.update!(name: "Joe #{i}")
+            end
+          end
+        ]
+      end
+      .flatten
+      .each(&:join)
+
+    assert_equal 5, user.versions.count
+  end
+end

--- a/test/test_thread_safety.rb
+++ b/test/test_thread_safety.rb
@@ -3,9 +3,7 @@ require "helper"
 class TestThreadSafety < ActiveSupport::TestCase
   private attr_reader :threads_count
 
-  setup do
-    @threads_count = 5
-  end
+  setup { @threads_count = 5 }
 
   test "whodunnit respects thread-safety" do
     threads =


### PR DESCRIPTION
follow up to #64, which adds thread-safety to the model's class method `with_hoardable_config` as well. also adds a new test file for thread safety checks.

closes https://github.com/waymondo/hoardable/issues/65