### PR TITLE
fix: Ensure we consult the inheritance_column rather than assuming 'type'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.19.2
+
+- Consult `inheritance_column` when constructing default scope
+
 ## 0.19.1
 
 - Thread-safety support added for `with_hoardable_config`.

--- a/lib/hoardable/scopes.rb
+++ b/lib/hoardable/scopes.rb
@@ -20,9 +20,9 @@ module Hoardable
               exclude_versions
             end
           )
-        next scope unless klass == version_class && "type".in?(column_names)
+        next scope unless klass == version_class && inheritance_column.in?(column_names)
 
-        scope.where(type: superclass.sti_name)
+        scope.where(inheritance_column => superclass.sti_name)
       end
 
       # @!scope class

--- a/lib/hoardable/scopes.rb
+++ b/lib/hoardable/scopes.rb
@@ -20,9 +20,9 @@ module Hoardable
               exclude_versions
             end
           )
-        next scope unless klass == version_class && inheritance_column.in?(column_names)
+        next scope unless klass == version_class && superclass.inheritance_column.in?(column_names)
 
-        scope.where(inheritance_column => superclass.sti_name)
+        scope.where(superclass.inheritance_column => superclass.sti_name)
       end
 
       # @!scope class

--- a/lib/hoardable/version.rb
+++ b/lib/hoardable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hoardable
-  VERSION = "0.19.1"
+  VERSION = "0.19.2"
 end


### PR DESCRIPTION
This fixes a bug in the Hoardable STI support where:
  - Source table tas a `type` column
  - Does not use STI
  
If the source table (let's say a `Question` model) has a `type` column, the default scope builder in Hoardable will incorrectly add it to the scope, which will break Hoardable on that model.

```
# Note: The Question model disables STI via: self.inheritance_column = :_sti_disabled
Question.where(bloo: "blah").where_clause.to_h # =>  {"type"=>"Question", "bloo"=>"blah"}
```
This also breaks Hoardable when it tries to `insert_version_record`, because the `type` column is overwritten with the source model class name.

Anyway, I am thinking it's happening because Hoardable is currently assuming the column name for STI on the source model is `type`. But actually it's whatever `inhertitance_column` is defined as.

So I reckon we should consult that value instead of hard-coding `type`.

This will fix both the issue I am facing but also any future issues where apps _are_ using STI, but have a custom column name for it.

Keen on thoughts!